### PR TITLE
Add sequence completion game mode

### DIFF
--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/core/presentation/navigation/NavGraph.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/core/presentation/navigation/NavGraph.kt
@@ -16,6 +16,7 @@ import eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_double.presentation
 import eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_write.presentation.ui.MathWriteGameScreen
 import eu.indiewalkabout.mathbrainer.feat_games.feat_math_random_operation.presentation.ui.RandomOperationGameScreen
 import eu.indiewalkabout.mathbrainer.feat_games.feat_number_order.presentation.ui.NumberOrderGameScreen
+import eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.presentation.ui.SequenceCompleteGameScreen
 import eu.indiewalkabout.mathbrainer.feat_home.presentation.ui.HomeScreen
 import eu.indiewalkabout.mathbrainer.feat_home.presentation.ui.HomeViewModel
 import eu.indiewalkabout.mathbrainer.feat_settings.presentation.ui.GameSettingsScreen
@@ -141,6 +142,21 @@ fun NavGraph(
         ) { backStackEntry ->
             val highScore = backStackEntry.arguments?.getInt("highScore") ?: 0
             CountObjectsGameScreen(
+                initialHighScore = highScore,
+                onBack = { navController.popBackStack() }
+            )
+        }
+
+        // --- Sequence Completion Game ---
+        composable(
+            route = ScreenRoutes.SequenceCompleteGame.route,
+            arguments = listOf(
+                navArgument("highScore") { type = NavType.IntType }
+            )
+        ) { backStackEntry ->
+            val highScore = backStackEntry.arguments?.getInt("highScore") ?: 0
+
+            SequenceCompleteGameScreen(
                 initialHighScore = highScore,
                 onBack = { navController.popBackStack() }
             )

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/core/presentation/navigation/ScreenRoutes.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/core/presentation/navigation/ScreenRoutes.kt
@@ -30,6 +30,9 @@ sealed class ScreenRoutes(val route: String) {
     object NumberOrderGame : ScreenRoutes("number_order_game/{highScore}") {
         fun createRoute(highScore: Int = 0): String = "number_order_game/$highScore"
     }
+    object SequenceCompleteGame : ScreenRoutes("sequence_complete_game/{highScore}") {
+        fun createRoute(highScore: Int = 0): String = "sequence_complete_game/$highScore"
+    }
     object GameSettings : ScreenRoutes("game_settings")
     object GameCredits : ScreenRoutes("game_credits")
     object Statistics : ScreenRoutes("statistics")

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_op_write/presentation/components/keyboard/Keypad.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_op_write/presentation/components/keyboard/Keypad.kt
@@ -1,7 +1,9 @@
 package eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_write.presentation.components.keyboard
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -24,22 +26,44 @@ fun Keypad(
     inputValue: String,
     onDigitPressed: (Int) -> Unit,
     onDelete: () -> Unit,
-    onSubmit: () -> Unit
+    onSubmit: () -> Unit,
+    isCompact: Boolean = false
 ) {
-    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
-        Column(modifier = Modifier.Companion.padding(16.dp)) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = if (isCompact) 4.dp else 8.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(if (isCompact) 4.dp else 8.dp)
+        ) {
             LazyVerticalGrid(
                 columns = GridCells.Fixed(3),
-                contentPadding = PaddingValues(4.dp)
+                contentPadding = PaddingValues(if (isCompact) 2.dp else 4.dp),
+                verticalArrangement = Arrangement.spacedBy(if (isCompact) 2.dp else 4.dp),
+                horizontalArrangement = Arrangement.spacedBy(if (isCompact) 2.dp else 4.dp),
+                modifier = Modifier.fillMaxWidth()
             ) {
                 items((1..9).toList()) { digit ->
-                    KeypadButton(text = digit.toString()) { onDigitPressed(digit) }
+                    KeypadButton(
+                        text = digit.toString(),
+                        isCompact = isCompact
+                    ) { onDigitPressed(digit) }
                 }
-                item { KeypadButton(text = "0") { onDigitPressed(0) } }
+                item { 
+                    KeypadButton(
+                        text = "0",
+                        isCompact = isCompact
+                    ) { onDigitPressed(0) } 
+                }
                 item {
                     KeypadButton(
                         icon = Icons.Default.Backspace,
-                        contentDescription = R.string.delete_label
+                        contentDescription = R.string.delete_label,
+                        isCompact = isCompact
                     ) {
                         onDelete()
                     }
@@ -47,7 +71,8 @@ fun Keypad(
                 item {
                     KeypadButton(
                         text = stringResource(id = R.string.submit_label),
-                        highlight = true
+                        highlight = true,
+                        isCompact = isCompact
                     ) {
                         onSubmit()
                     }

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_op_write/presentation/components/keyboard/KeypadButton.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_op_write/presentation/components/keyboard/KeypadButton.kt
@@ -4,6 +4,7 @@ import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -24,12 +25,13 @@ fun KeypadButton(
     icon: ImageVector? = null,
     @StringRes contentDescription: Int? = null,
     highlight: Boolean = false,
+    isCompact: Boolean = false,
     onClick: () -> Unit
 ) {
     Card(
-        modifier = Modifier.Companion
-            .padding(6.dp)
-            .fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(if (isCompact) 2.dp else 4.dp),
         colors = CardDefaults.cardColors(
             containerColor = if (highlight) MaterialTheme.colorScheme.primary
             else MaterialTheme.colorScheme.surfaceVariant
@@ -38,22 +40,26 @@ fun KeypadButton(
         onClick = onClick
     ) {
         Box(
-            modifier = Modifier.Companion
+            modifier = Modifier
                 .fillMaxWidth()
-                .padding(vertical = 14.dp),
-            contentAlignment = Alignment.Companion.Center
+                .padding(vertical = if (isCompact) 6.dp else 12.dp),
+            contentAlignment = Alignment.Center
         ) {
             when {
                 icon != null -> Icon(
                     imageVector = icon,
                     contentDescription = contentDescription?.let { stringResource(id = it) },
-                    tint = if (highlight) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
+                    tint = if (highlight) MaterialTheme.colorScheme.onPrimary 
+                          else MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(if (isCompact) 20.dp else 24.dp)
                 )
 
                 text != null -> Text(
                     text = text,
-                    style = MaterialTheme.typography.titleMedium,
-                    color = if (highlight) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
+                    style = if (isCompact) MaterialTheme.typography.bodyLarge
+                          else MaterialTheme.typography.titleMedium,
+                    color = if (highlight) MaterialTheme.colorScheme.onPrimary 
+                          else MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
         }

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/domain/model/SequenceChallenge.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/domain/model/SequenceChallenge.kt
@@ -4,7 +4,8 @@ data class SequenceChallenge(
     val displaySequence: List<Int?>,
     val fullSequence: List<Int>,
     val ruleSteps: List<SequenceRuleStep>,
-    val ruleDescription: String
+    val ruleDescription: String,
+    val missingPosition: Int
 ) {
-    val answer: Int = fullSequence.last()
+    val answer: Int = fullSequence[missingPosition]
 }

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/domain/model/SequenceChallenge.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/domain/model/SequenceChallenge.kt
@@ -1,0 +1,10 @@
+package eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.domain.model
+
+data class SequenceChallenge(
+    val displaySequence: List<Int?>,
+    val fullSequence: List<Int>,
+    val ruleSteps: List<SequenceRuleStep>,
+    val ruleDescription: String
+) {
+    val answer: Int = fullSequence.last()
+}

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/domain/model/SequenceConfig.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/domain/model/SequenceConfig.kt
@@ -1,0 +1,10 @@
+package eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.domain.model
+
+data class SequenceConfig(
+    val level: Int,
+    val minStart: Int,
+    val maxStart: Int,
+    val maxStepMagnitude: Int,
+    val length: Int,
+    val maxValue: Int = 9_999
+)

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/domain/model/SequenceRuleStep.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/domain/model/SequenceRuleStep.kt
@@ -1,0 +1,24 @@
+package eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.domain.model
+
+enum class SequenceOperation(val symbol: String) {
+    ADD("+"),
+    SUBTRACT("-"),
+    MULTIPLY("×");
+}
+
+data class SequenceRuleStep(
+    val operation: SequenceOperation,
+    val value: Int
+) {
+    fun apply(to: Int): Int = when (operation) {
+        SequenceOperation.ADD -> to + value
+        SequenceOperation.SUBTRACT -> to - value
+        SequenceOperation.MULTIPLY -> to * value
+    }
+
+    fun describe(): String = when (operation) {
+        SequenceOperation.ADD -> "+$value"
+        SequenceOperation.SUBTRACT -> "-$value"
+        SequenceOperation.MULTIPLY -> "×$value"
+    }
+}

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/domain/use_cases/GenerateSequenceChallengeUseCase.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/domain/use_cases/GenerateSequenceChallengeUseCase.kt
@@ -28,27 +28,33 @@ class GenerateSequenceChallengeUseCase @Inject constructor() {
 
             if (isValid && numbers.size == config.length) {
                 val ruleDescription = formatRuleDescription(steps)
+                // Randomly select a position to hide (excluding the first number to ensure solvability)
+                val missingPosition = Random.nextInt(1, numbers.size)
                 val displaySequence = numbers.mapIndexed { index, value ->
-                    if (index == numbers.lastIndex) null else value
+                    if (index == missingPosition) null else value
                 }
                 return SequenceChallenge(
                     displaySequence = displaySequence,
                     fullSequence = numbers,
                     ruleSteps = steps,
-                    ruleDescription = ruleDescription
+                    ruleDescription = ruleDescription,
+                    missingPosition = missingPosition
                 )
             }
         }
 
         val fallbackNumbers = (config.minStart until (config.minStart + config.length)).toList()
         val fallbackSteps = listOf(SequenceRuleStep(SequenceOperation.ADD, 1))
+        // For fallback, hide the last number
+        val missingPosition = fallbackNumbers.lastIndex
         return SequenceChallenge(
             displaySequence = fallbackNumbers.mapIndexed { index, value ->
-                if (index == fallbackNumbers.lastIndex) null else value
+                if (index == missingPosition) null else value
             },
             fullSequence = fallbackNumbers,
             ruleSteps = fallbackSteps,
-            ruleDescription = formatRuleDescription(fallbackSteps)
+            ruleDescription = formatRuleDescription(fallbackSteps),
+            missingPosition = missingPosition
         )
     }
 

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/domain/use_cases/GenerateSequenceChallengeUseCase.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/domain/use_cases/GenerateSequenceChallengeUseCase.kt
@@ -1,0 +1,94 @@
+package eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.domain.use_cases
+
+import eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.domain.model.SequenceChallenge
+import eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.domain.model.SequenceConfig
+import eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.domain.model.SequenceOperation
+import eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.domain.model.SequenceRuleStep
+import javax.inject.Inject
+import kotlin.random.Random
+
+class GenerateSequenceChallengeUseCase @Inject constructor() {
+
+    operator fun invoke(config: SequenceConfig): SequenceChallenge {
+        repeat(MAX_ATTEMPTS) {
+            val steps = buildSteps(config)
+            val start = Random.nextInt(config.minStart, config.maxStart.coerceAtLeast(config.minStart) + 1)
+            val numbers = mutableListOf(start)
+
+            var isValid = true
+            while (numbers.size < config.length && isValid) {
+                val step = steps[(numbers.size - 1) % steps.size]
+                val next = step.apply(numbers.last())
+                if (next <= 0 || next > config.maxValue) {
+                    isValid = false
+                } else {
+                    numbers.add(next)
+                }
+            }
+
+            if (isValid && numbers.size == config.length) {
+                val ruleDescription = formatRuleDescription(steps)
+                val displaySequence = numbers.mapIndexed { index, value ->
+                    if (index == numbers.lastIndex) null else value
+                }
+                return SequenceChallenge(
+                    displaySequence = displaySequence,
+                    fullSequence = numbers,
+                    ruleSteps = steps,
+                    ruleDescription = ruleDescription
+                )
+            }
+        }
+
+        val fallbackNumbers = (config.minStart until (config.minStart + config.length)).toList()
+        val fallbackSteps = listOf(SequenceRuleStep(SequenceOperation.ADD, 1))
+        return SequenceChallenge(
+            displaySequence = fallbackNumbers.mapIndexed { index, value ->
+                if (index == fallbackNumbers.lastIndex) null else value
+            },
+            fullSequence = fallbackNumbers,
+            ruleSteps = fallbackSteps,
+            ruleDescription = formatRuleDescription(fallbackSteps)
+        )
+    }
+
+    private fun buildSteps(config: SequenceConfig): List<SequenceRuleStep> {
+        val stepCount = when {
+            config.level >= 8 -> 3
+            config.level >= 4 -> 2
+            else -> 1
+        }
+
+        val operationsPool = when {
+            config.level >= 6 -> listOf(SequenceOperation.ADD, SequenceOperation.SUBTRACT, SequenceOperation.MULTIPLY)
+            config.level >= 3 -> listOf(SequenceOperation.ADD, SequenceOperation.MULTIPLY, SequenceOperation.SUBTRACT)
+            else -> listOf(SequenceOperation.ADD, SequenceOperation.MULTIPLY)
+        }
+
+        val maxStep = config.maxStepMagnitude.coerceAtLeast(2)
+
+        return List(stepCount) {
+            val operation = operationsPool.random()
+            val value = when (operation) {
+                SequenceOperation.ADD -> Random.nextInt(1, maxStep + 1)
+                SequenceOperation.SUBTRACT -> Random.nextInt(1, maxStep)
+                SequenceOperation.MULTIPLY -> Random.nextInt(2, maxStep.coerceAtMost(MAX_MULTIPLIER) + 1)
+            }
+            SequenceRuleStep(operation, value)
+        }
+    }
+
+    private fun formatRuleDescription(steps: List<SequenceRuleStep>): String {
+        if (steps.isEmpty()) return ""
+        return if (steps.size == 1) {
+            "Repeat ${steps.first().describe()} each step"
+        } else {
+            steps.joinToString(separator = " then ") { it.describe() } + " (repeat)"
+        }
+    }
+
+    companion object {
+        private const val MAX_MULTIPLIER = 7
+        private const val MAX_ATTEMPTS = 50
+    }
+}

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/domain/use_cases/UpdateSequenceCompleteScoreUseCase.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/domain/use_cases/UpdateSequenceCompleteScoreUseCase.kt
@@ -1,0 +1,21 @@
+package eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.domain.use_cases
+
+import eu.indiewalkabout.mathbrainer.feat_statistics.domain.model.GameScores.Companion.emptyScores
+import eu.indiewalkabout.mathbrainer.feat_statistics.domain.repository.MathBrainerRepository
+import javax.inject.Inject
+import kotlin.math.max
+import kotlinx.coroutines.flow.firstOrNull
+
+class UpdateSequenceCompleteScoreUseCase @Inject constructor(
+    private val repository: MathBrainerRepository
+) {
+    suspend operator fun invoke(sessionScore: Int) {
+        val currentScores = repository.observeGameScores().firstOrNull() ?: emptyScores
+        val updatedScores = currentScores.copy(
+            sequence_complete_game_score = max(currentScores.sequence_complete_game_score, sessionScore),
+            id = 0,
+            global_score = currentScores.global_score + sessionScore
+        )
+        repository.insertGameScores(updatedScores)
+    }
+}

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/presentation/components/SequenceChallengeCard.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/presentation/components/SequenceChallengeCard.kt
@@ -1,0 +1,97 @@
+package eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.presentation.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import eu.indiewalkabout.mathbrainer.R
+import eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.presentation.state.SequenceCompleteUiState
+
+@Composable
+fun SequenceChallengeCard(state: SequenceCompleteUiState) {
+    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(
+                text = stringResource(id = R.string.sequence_prompt),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                state.visibleSequence.forEachIndexed { index, number ->
+                    SequenceNumberChip(
+                        text = number?.toString() ?: "?",
+                        highlighted = index == state.visibleSequence.lastIndex && state.revealedAnswer != null
+                    )
+                }
+            }
+
+            state.ruleDescription?.let { rule ->
+                Text(
+                    text = stringResource(id = R.string.sequence_rule_reveal, rule),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+
+            state.revealedAnswer?.let { answer ->
+                Text(
+                    text = stringResource(id = R.string.sequence_correct_answer, answer),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SequenceNumberChip(
+    text: String,
+    highlighted: Boolean
+) {
+    Card(
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = if (highlighted) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.secondaryContainer
+        )
+    ) {
+        Text(
+            text = text,
+            modifier = Modifier
+                .padding(horizontal = 12.dp, vertical = 10.dp)
+                .height(28.dp),
+            style = MaterialTheme.typography.bodyLarge.copy(
+                fontWeight = FontWeight.Bold,
+                letterSpacing = 0.5.sp
+            ),
+            color = if (highlighted) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSecondaryContainer,
+            textAlign = TextAlign.Center
+        )
+    }
+}

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/presentation/components/SequenceChallengeCard.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/presentation/components/SequenceChallengeCard.kt
@@ -3,20 +3,26 @@ package eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.presenta
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -24,20 +30,23 @@ import eu.indiewalkabout.mathbrainer.R
 import eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.presentation.state.SequenceCompleteUiState
 
 @Composable
-fun SequenceChallengeCard(state: SequenceCompleteUiState) {
-    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
+fun SequenceChallengeCard(
+    state: SequenceCompleteUiState
+) {
+    val feedbackColor = when (state.feedback) {
+        SequenceCompleteUiState.Feedback.SUCCESS -> MaterialTheme.colorScheme.primary
+        SequenceCompleteUiState.Feedback.FAILURE -> MaterialTheme.colorScheme.error
+        else -> MaterialTheme.colorScheme.onSecondaryContainer
+    }
+    
+    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer)) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Text(
-                text = stringResource(id = R.string.sequence_prompt),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface
-            )
-
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceEvenly,
@@ -46,10 +55,51 @@ fun SequenceChallengeCard(state: SequenceCompleteUiState) {
                 state.visibleSequence.forEachIndexed { index, number ->
                     SequenceNumberChip(
                         text = number?.toString() ?: "?",
-                        highlighted = index == state.visibleSequence.lastIndex && state.revealedAnswer != null
+                        highlighted = index == state.visibleSequence.lastIndex && state.revealedAnswer != null,
+                        textColor = if (state.feedback != null) feedbackColor else null
                     )
                 }
             }
+
+            // Input field for the answer
+            TextField(
+                value = state.inputValue,
+                onValueChange = {},
+                readOnly = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .wrapContentHeight(),
+                    // .height(54.dp),
+                textStyle = MaterialTheme.typography.headlineMedium.copy(
+                    textAlign = TextAlign.Center,
+                    color = if (state.feedback != null) feedbackColor else MaterialTheme.colorScheme.onSecondaryContainer,
+                    // lineHeight = 40.sp
+                ),
+                colors = TextFieldDefaults.colors(
+                    focusedContainerColor = MaterialTheme.colorScheme.background,
+                    unfocusedContainerColor = MaterialTheme.colorScheme.background,
+                    disabledContainerColor = MaterialTheme.colorScheme.background,
+                    focusedIndicatorColor = Color.Transparent,
+                    unfocusedIndicatorColor = Color.Transparent,
+                    cursorColor = Color.Transparent
+                ),
+                visualTransformation = VisualTransformation.None,
+                keyboardOptions = KeyboardOptions.Default.copy(
+                    imeAction = ImeAction.None
+                ),
+                placeholder = { 
+                    if (state.inputValue.isBlank()) {
+                        Text(
+                            text = stringResource(id = R.string.sequence_prompt),
+                            style = MaterialTheme.typography.labelSmall.copy(
+                                textAlign = TextAlign.Center,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                            )
+                        )
+                    }
+                },
+                singleLine = true
+            )
 
             state.ruleDescription?.let { rule ->
                 Text(
@@ -59,13 +109,7 @@ fun SequenceChallengeCard(state: SequenceCompleteUiState) {
                 )
             }
 
-            state.revealedAnswer?.let { answer ->
-                Text(
-                    text = stringResource(id = R.string.sequence_correct_answer, answer),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
+
         }
     }
 }
@@ -73,7 +117,8 @@ fun SequenceChallengeCard(state: SequenceCompleteUiState) {
 @Composable
 private fun SequenceNumberChip(
     text: String,
-    highlighted: Boolean
+    highlighted: Boolean,
+    textColor: Color? = null
 ) {
     Card(
         shape = RoundedCornerShape(12.dp),

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/presentation/components/SequenceChallengeCard.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/presentation/components/SequenceChallengeCard.kt
@@ -53,10 +53,20 @@ fun SequenceChallengeCard(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 state.visibleSequence.forEachIndexed { index, number ->
+                    val isMissingNumber = number == null
+                    val isRevealed = state.revealedAnswer != null && isMissingNumber
                     SequenceNumberChip(
-                        text = number?.toString() ?: "?",
-                        highlighted = index == state.visibleSequence.lastIndex && state.revealedAnswer != null,
-                        textColor = if (state.feedback != null) feedbackColor else null
+                        text = when {
+                            isRevealed -> state.revealedAnswer?.toString() ?: "?"
+                            isMissingNumber -> "?"
+                            else -> number.toString()
+                        },
+                        highlighted = isMissingNumber && state.revealedAnswer != null,
+                        textColor = when {
+                            isRevealed -> feedbackColor
+                            isMissingNumber && state.feedback != null -> feedbackColor
+                            else -> null
+                        }
                     )
                 }
             }

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/presentation/components/SequenceCompleteHeader.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/presentation/components/SequenceCompleteHeader.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -74,7 +73,7 @@ fun SequenceCompleteHeader(state: SequenceCompleteUiState) {
                         color = MaterialTheme.colorScheme.onSurface
                     )
                 }
-            }
+            }/*
 
             Spacer(modifier = Modifier.height(12.dp))
 
@@ -82,7 +81,7 @@ fun SequenceCompleteHeader(state: SequenceCompleteUiState) {
                 progress = state.timerProgress,
                 modifier = Modifier.fillMaxWidth(),
                 color = MaterialTheme.colorScheme.primary
-            )
+            )*/
         }
     }
 }

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/presentation/components/SequenceCompleteHeader.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/presentation/components/SequenceCompleteHeader.kt
@@ -1,0 +1,88 @@
+package eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.presentation.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import eu.indiewalkabout.mathbrainer.R
+import eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_write.presentation.components.LevelProgressBar
+import eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.presentation.state.SequenceCompleteUiState
+
+@Composable
+fun SequenceCompleteHeader(state: SequenceCompleteUiState) {
+    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = stringResource(id = R.string.level_with_value, state.level),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+
+                LevelProgressBar(
+                    currentProgress = state.challengesCompleted,
+                    totalSegments = state.challengesPerLevel,
+                    segmentColor = MaterialTheme.colorScheme.primary,
+                    backgroundColor = MaterialTheme.colorScheme.secondaryContainer,
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(horizontal = 16.dp)
+                        .height(8.dp)
+                )
+
+                Text(
+                    text = stringResource(id = R.string.lives_with_value, state.lives),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = stringResource(id = R.string.score_with_value, state.score),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.Bold
+                )
+                state.highScore?.let { highScore ->
+                    Text(
+                        text = stringResource(id = R.string.highscore_with_value, highScore),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            LinearProgressIndicator(
+                progress = state.timerProgress,
+                modifier = Modifier.fillMaxWidth(),
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
+    }
+}

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/presentation/state/SequenceCompleteUiState.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/presentation/state/SequenceCompleteUiState.kt
@@ -1,0 +1,29 @@
+package eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.presentation.state
+
+data class SequenceCompleteUiState(
+    val visibleSequence: List<Int?> = emptyList(),
+    val inputValue: String = "",
+    val score: Int = 0,
+    val highScore: Int? = null,
+    val level: Int = 1,
+    val challengesCompleted: Int = 0,
+    val challengesPerLevel: Int = INITIAL_CHALLENGES_PER_LEVEL,
+    val lives: Int = 3,
+    val feedback: Feedback? = null,
+    val isGameOver: Boolean = false,
+    val ruleDescription: String? = null,
+    val revealedAnswer: Int? = null,
+    val isReadyForNext: Boolean = false,
+    val timeRemaining: Long = INITIAL_TIMER_LENGTH,
+    val totalTime: Long = INITIAL_TIMER_LENGTH
+) {
+    val timerProgress: Float
+        get() = if (totalTime == 0L) 0f else (timeRemaining.toFloat() / totalTime.toFloat()).coerceIn(0f, 1f)
+
+    enum class Feedback { SUCCESS, FAILURE }
+
+    companion object {
+        const val INITIAL_TIMER_LENGTH: Long = 20_000L
+        const val INITIAL_CHALLENGES_PER_LEVEL: Int = 5
+    }
+}

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/presentation/ui/SequenceCompleteGameScreen.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/presentation/ui/SequenceCompleteGameScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
@@ -84,7 +85,7 @@ fun SequenceCompleteGameScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
-                .padding(16.dp),
+                .padding(horizontal = 16.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             SequenceCompleteHeader(state = state)
@@ -101,10 +102,7 @@ fun SequenceCompleteGameScreen(
                     color = MaterialTheme.colorScheme.error
                 )
 
-                null -> ResultBanner(
-                    text = stringResource(id = R.string.sequence_prompt),
-                    color = MaterialTheme.colorScheme.onBackground
-                )
+                null -> Spacer(modifier = Modifier.height(0.dp))
             }
 
             if (state.isReadyForNext && !state.isGameOver) {
@@ -114,14 +112,18 @@ fun SequenceCompleteGameScreen(
                 ) {
                     Text(text = stringResource(id = R.string.sequence_again))
                 }
+            } else {
+                Spacer(modifier = Modifier.height(0.dp))
             }
 
-            Keypad(
+Keypad(
                 inputValue = state.inputValue,
                 onDigitPressed = { digit -> viewModel.onDigitPressed(digit) },
                 onDelete = { viewModel.onDelete() },
-                onSubmit = { viewModel.submitAnswer() }
+                onSubmit = { viewModel.submitAnswer() },
+                isCompact = true
             )
+            Spacer(modifier = Modifier.padding(bottom = 8.dp))
         }
     }
 

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/presentation/ui/SequenceCompleteGameScreen.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/presentation/ui/SequenceCompleteGameScreen.kt
@@ -1,0 +1,134 @@
+package eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.presentation.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import eu.indiewalkabout.mathbrainer.R
+import eu.indiewalkabout.mathbrainer.core.presentation.components.GameOverDialog
+import eu.indiewalkabout.mathbrainer.core.presentation.components.ResultBanner
+import eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_write.presentation.components.keyboard.Keypad
+import eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.presentation.components.SequenceChallengeCard
+import eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.presentation.components.SequenceCompleteHeader
+import eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.presentation.state.SequenceCompleteUiState
+
+@Composable
+fun SequenceCompleteGameScreen(
+    initialHighScore: Int = 0,
+    onBack: () -> Unit,
+    viewModel: SequenceCompleteViewModel = hiltViewModel()
+) {
+    LaunchedEffect(initialHighScore) {
+        viewModel.startGame(initialHighScore)
+    }
+
+    val state by viewModel.uiState.collectAsState()
+
+    Scaffold(
+        topBar = {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(MaterialTheme.colorScheme.primary)
+                    .padding(horizontal = 12.dp, vertical = 16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = {
+                    viewModel.onQuitGame()
+                    onBack()
+                }) {
+                    Icon(
+                        imageVector = Icons.Default.ArrowBack,
+                        contentDescription = stringResource(id = R.string.navigate_back),
+                        tint = MaterialTheme.colorScheme.onPrimary
+                    )
+                }
+                Spacer(modifier = Modifier.padding(4.dp))
+                Column {
+                    Text(
+                        text = stringResource(id = R.string.sequence_complete_title),
+                        style = MaterialTheme.typography.titleLarge,
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                    Text(
+                        text = stringResource(id = R.string.sequence_complete_description),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                }
+            }
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            SequenceCompleteHeader(state = state)
+            SequenceChallengeCard(state = state)
+
+            when (state.feedback) {
+                SequenceCompleteUiState.Feedback.SUCCESS -> ResultBanner(
+                    text = stringResource(id = R.string.sequence_feedback_success),
+                    color = MaterialTheme.colorScheme.primary
+                )
+
+                SequenceCompleteUiState.Feedback.FAILURE -> ResultBanner(
+                    text = stringResource(id = R.string.sequence_feedback_failure),
+                    color = MaterialTheme.colorScheme.error
+                )
+
+                null -> ResultBanner(
+                    text = stringResource(id = R.string.sequence_prompt),
+                    color = MaterialTheme.colorScheme.onBackground
+                )
+            }
+
+            if (state.isReadyForNext && !state.isGameOver) {
+                Button(
+                    onClick = { viewModel.onNextChallenge() },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(text = stringResource(id = R.string.sequence_again))
+                }
+            }
+
+            Keypad(
+                inputValue = state.inputValue,
+                onDigitPressed = { digit -> viewModel.onDigitPressed(digit) },
+                onDelete = { viewModel.onDelete() },
+                onSubmit = { viewModel.submitAnswer() }
+            )
+        }
+    }
+
+    if (state.isGameOver) {
+        GameOverDialog(onDismiss = {
+            viewModel.onQuitGame()
+            onBack()
+        })
+    }
+}

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/presentation/ui/SequenceCompleteViewModel.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/presentation/ui/SequenceCompleteViewModel.kt
@@ -1,0 +1,247 @@
+package eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.presentation.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.domain.model.SequenceChallenge
+import eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.domain.model.SequenceConfig
+import eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.domain.use_cases.GenerateSequenceChallengeUseCase
+import eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.domain.use_cases.UpdateSequenceCompleteScoreUseCase
+import eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.presentation.state.SequenceCompleteUiState
+import javax.inject.Inject
+import kotlin.math.max
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class SequenceCompleteViewModel @Inject constructor(
+    private val generateSequenceChallengeUseCase: GenerateSequenceChallengeUseCase,
+    private val updateSequenceCompleteScoreUseCase: UpdateSequenceCompleteScoreUseCase
+) : ViewModel() {
+
+    private var timerJob: Job? = null
+    private var timerLength: Long = SequenceCompleteUiState.INITIAL_TIMER_LENGTH
+    private var challengesCompletedInternal = 0
+    private var challengesPerLevelInternal = SequenceCompleteUiState.INITIAL_CHALLENGES_PER_LEVEL
+    private var isScorePersisted = false
+    private var currentChallenge: SequenceChallenge? = null
+
+    private val _uiState = MutableStateFlow(SequenceCompleteUiState())
+    val uiState: StateFlow<SequenceCompleteUiState> = _uiState.asStateFlow()
+
+    fun startGame(initialHighScore: Int = 0) {
+        isScorePersisted = false
+        challengesCompletedInternal = 0
+        challengesPerLevelInternal = SequenceCompleteUiState.INITIAL_CHALLENGES_PER_LEVEL
+        timerLength = SequenceCompleteUiState.INITIAL_TIMER_LENGTH
+
+        _uiState.update {
+            it.copy(
+                highScore = initialHighScore.takeIf { score -> score > 0 },
+                score = 0,
+                level = 1,
+                lives = 3,
+                feedback = null,
+                isGameOver = false,
+                challengesCompleted = 0,
+                challengesPerLevel = SequenceCompleteUiState.INITIAL_CHALLENGES_PER_LEVEL,
+                ruleDescription = null,
+                revealedAnswer = null,
+                isReadyForNext = false,
+                timeRemaining = timerLength,
+                totalTime = timerLength
+            )
+        }
+
+        viewModelScope.launch { launchNewChallenge(resetTimer = true) }
+    }
+
+    fun onDigitPressed(digit: Int) {
+        if (_uiState.value.isGameOver || _uiState.value.isReadyForNext) return
+        _uiState.update { it.copy(inputValue = (it.inputValue + digit.toString()).take(7)) }
+    }
+
+    fun onDelete() {
+        if (_uiState.value.isGameOver || _uiState.value.isReadyForNext) return
+        _uiState.update { current ->
+            val newValue = if (current.inputValue.isNotEmpty()) current.inputValue.dropLast(1) else ""
+            current.copy(inputValue = newValue)
+        }
+    }
+
+    fun submitAnswer() {
+        if (_uiState.value.isGameOver || _uiState.value.isReadyForNext) return
+        val challenge = currentChallenge ?: return
+        val attempt = _uiState.value.inputValue.toIntOrNull() ?: return
+        timerJob?.cancel()
+
+        if (attempt == challenge.answer) {
+            handleSuccess(challenge)
+        } else {
+            handleFailure(challenge)
+        }
+    }
+
+    fun onNextChallenge() {
+        if (_uiState.value.isGameOver || !_uiState.value.isReadyForNext) return
+        viewModelScope.launch { launchNewChallenge(resetTimer = true) }
+    }
+
+    fun onQuitGame() {
+        persistScoreIfNeeded()
+    }
+
+    private suspend fun launchNewChallenge(resetTimer: Boolean) {
+        val config = buildConfig()
+        val challenge = generateSequenceChallengeUseCase(config)
+        currentChallenge = challenge
+
+        _uiState.update {
+            it.copy(
+                visibleSequence = challenge.displaySequence,
+                inputValue = "",
+                feedback = null,
+                ruleDescription = null,
+                revealedAnswer = null,
+                isReadyForNext = false,
+                timeRemaining = timerLength,
+                totalTime = timerLength
+            )
+        }
+
+        if (resetTimer) {
+            startTimer()
+        }
+    }
+
+    private fun startTimer() {
+        timerJob?.cancel()
+        timerJob = viewModelScope.launch {
+            var remaining = timerLength
+            while (remaining > 0 && !_uiState.value.isReadyForNext && !_uiState.value.isGameOver) {
+                delay(COUNTDOWN_STEP)
+                remaining -= COUNTDOWN_STEP
+                _uiState.update { it.copy(timeRemaining = remaining) }
+            }
+            if (!_uiState.value.isReadyForNext && !_uiState.value.isGameOver) {
+                currentChallenge?.let { handleFailure(it) }
+            }
+        }
+    }
+
+    private fun handleSuccess(challenge: SequenceChallenge) {
+        val newScore = _uiState.value.score + SCORE_INCREMENT
+        val shouldLevelUp = challengesCompletedInternal + 1 >= challengesPerLevelInternal
+
+        val (nextLevel, nextChallengesPerLevel) = if (shouldLevelUp) {
+            challengesCompletedInternal = 0
+            promoteLevel(_uiState.value.level)
+        } else {
+            challengesCompletedInternal++
+            _uiState.value.level to challengesPerLevelInternal
+        }
+
+        _uiState.update {
+            it.copy(
+                feedback = SequenceCompleteUiState.Feedback.SUCCESS,
+                score = newScore,
+                highScore = max(it.highScore ?: 0, newScore),
+                challengesCompleted = challengesCompletedInternal,
+                challengesPerLevel = nextChallengesPerLevel,
+                level = nextLevel,
+                ruleDescription = challenge.ruleDescription,
+                revealedAnswer = challenge.answer,
+                visibleSequence = revealSequence(challenge),
+                isReadyForNext = true,
+                timeRemaining = timerLength,
+                totalTime = timerLength
+            )
+        }
+    }
+
+    private fun handleFailure(challenge: SequenceChallenge) {
+        timerJob?.cancel()
+        val remainingLives = _uiState.value.lives - 1
+        _uiState.update {
+            it.copy(
+                lives = remainingLives,
+                feedback = SequenceCompleteUiState.Feedback.FAILURE,
+                ruleDescription = challenge.ruleDescription,
+                revealedAnswer = challenge.answer,
+                visibleSequence = revealSequence(challenge),
+                isReadyForNext = remainingLives > 0,
+                timeRemaining = 0L
+            )
+        }
+
+        if (remainingLives <= 0) {
+            onGameOver()
+        }
+    }
+
+    private fun promoteLevel(currentLevel: Int): Pair<Int, Int> {
+        val nextLevel = currentLevel + 1
+        val nextChallengesPerLevel = (SequenceCompleteUiState.INITIAL_CHALLENGES_PER_LEVEL + (nextLevel / 2)).coerceAtMost(MAX_CHALLENGES_PER_LEVEL)
+        challengesPerLevelInternal = nextChallengesPerLevel
+        timerLength = (SequenceCompleteUiState.INITIAL_TIMER_LENGTH - nextLevel * TIMER_DECREASE_PER_LEVEL).coerceAtLeast(MIN_TIMER_LENGTH)
+        return nextLevel to nextChallengesPerLevel
+    }
+
+    private fun onGameOver() {
+        timerJob?.cancel()
+        _uiState.update { it.copy(isGameOver = true, isReadyForNext = false) }
+        persistScoreIfNeeded()
+    }
+
+    private fun persistScoreIfNeeded() {
+        if (isScorePersisted) return
+        isScorePersisted = true
+        val finalScore = _uiState.value.score
+        if (finalScore <= 0) return
+        viewModelScope.launch {
+            updateSequenceCompleteScoreUseCase(finalScore)
+        }
+    }
+
+    private fun buildConfig(): SequenceConfig {
+        val level = _uiState.value.level
+        val length = (BASE_SEQUENCE_LENGTH + (level - 1) / 2).coerceAtMost(MAX_SEQUENCE_LENGTH)
+        val maxStep = (BASE_STEP_MAGNITUDE + level * STEP_GROWTH).coerceAtMost(MAX_STEP_MAGNITUDE)
+        val maxStart = (BASE_START_MAX + level * START_GROWTH).coerceAtMost(MAX_START_VALUE)
+
+        return SequenceConfig(
+            level = level,
+            minStart = 1,
+            maxStart = maxStart,
+            maxStepMagnitude = maxStep,
+            length = length,
+            maxValue = MAX_VALUE
+        )
+    }
+
+    private fun revealSequence(challenge: SequenceChallenge): List<Int?> {
+        return challenge.fullSequence.map { value -> value }
+    }
+
+    companion object {
+        private const val SCORE_INCREMENT = 25
+        private const val COUNTDOWN_STEP = 1_000L
+        private const val TIMER_DECREASE_PER_LEVEL = 500L
+        private const val MIN_TIMER_LENGTH = 12_000L
+        private const val MAX_VALUE = 9_999
+        private const val BASE_SEQUENCE_LENGTH = 4
+        private const val MAX_SEQUENCE_LENGTH = 6
+        private const val BASE_STEP_MAGNITUDE = 3
+        private const val STEP_GROWTH = 2
+        private const val MAX_STEP_MAGNITUDE = 12
+        private const val BASE_START_MAX = 15
+        private const val START_GROWTH = 12
+        private const val MAX_START_VALUE = 5_000
+        private const val MAX_CHALLENGES_PER_LEVEL = 12
+    }
+}

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/presentation/ui/SequenceCompleteViewModel.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/presentation/ui/SequenceCompleteViewModel.kt
@@ -8,15 +8,13 @@ import eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.domain.mo
 import eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.domain.use_cases.GenerateSequenceChallengeUseCase
 import eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.domain.use_cases.UpdateSequenceCompleteScoreUseCase
 import eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.presentation.state.SequenceCompleteUiState
-import javax.inject.Inject
-import kotlin.math.max
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import javax.inject.Inject
+import kotlin.math.max
 
 @HiltViewModel
 class SequenceCompleteViewModel @Inject constructor(
@@ -24,8 +22,6 @@ class SequenceCompleteViewModel @Inject constructor(
     private val updateSequenceCompleteScoreUseCase: UpdateSequenceCompleteScoreUseCase
 ) : ViewModel() {
 
-    private var timerJob: Job? = null
-    private var timerLength: Long = SequenceCompleteUiState.INITIAL_TIMER_LENGTH
     private var challengesCompletedInternal = 0
     private var challengesPerLevelInternal = SequenceCompleteUiState.INITIAL_CHALLENGES_PER_LEVEL
     private var isScorePersisted = false
@@ -38,7 +34,6 @@ class SequenceCompleteViewModel @Inject constructor(
         isScorePersisted = false
         challengesCompletedInternal = 0
         challengesPerLevelInternal = SequenceCompleteUiState.INITIAL_CHALLENGES_PER_LEVEL
-        timerLength = SequenceCompleteUiState.INITIAL_TIMER_LENGTH
 
         _uiState.update {
             it.copy(
@@ -52,13 +47,11 @@ class SequenceCompleteViewModel @Inject constructor(
                 challengesPerLevel = SequenceCompleteUiState.INITIAL_CHALLENGES_PER_LEVEL,
                 ruleDescription = null,
                 revealedAnswer = null,
-                isReadyForNext = false,
-                timeRemaining = timerLength,
-                totalTime = timerLength
+                isReadyForNext = false
             )
         }
 
-        viewModelScope.launch { launchNewChallenge(resetTimer = true) }
+        viewModelScope.launch { launchNewChallenge() }
     }
 
     fun onDigitPressed(digit: Int) {
@@ -78,7 +71,6 @@ class SequenceCompleteViewModel @Inject constructor(
         if (_uiState.value.isGameOver || _uiState.value.isReadyForNext) return
         val challenge = currentChallenge ?: return
         val attempt = _uiState.value.inputValue.toIntOrNull() ?: return
-        timerJob?.cancel()
 
         if (attempt == challenge.answer) {
             handleSuccess(challenge)
@@ -89,14 +81,14 @@ class SequenceCompleteViewModel @Inject constructor(
 
     fun onNextChallenge() {
         if (_uiState.value.isGameOver || !_uiState.value.isReadyForNext) return
-        viewModelScope.launch { launchNewChallenge(resetTimer = true) }
+        viewModelScope.launch { launchNewChallenge() }
     }
 
     fun onQuitGame() {
         persistScoreIfNeeded()
     }
 
-    private suspend fun launchNewChallenge(resetTimer: Boolean) {
+    private fun launchNewChallenge() {
         val config = buildConfig()
         val challenge = generateSequenceChallengeUseCase(config)
         currentChallenge = challenge
@@ -108,29 +100,8 @@ class SequenceCompleteViewModel @Inject constructor(
                 feedback = null,
                 ruleDescription = null,
                 revealedAnswer = null,
-                isReadyForNext = false,
-                timeRemaining = timerLength,
-                totalTime = timerLength
+                isReadyForNext = false
             )
-        }
-
-        if (resetTimer) {
-            startTimer()
-        }
-    }
-
-    private fun startTimer() {
-        timerJob?.cancel()
-        timerJob = viewModelScope.launch {
-            var remaining = timerLength
-            while (remaining > 0 && !_uiState.value.isReadyForNext && !_uiState.value.isGameOver) {
-                delay(COUNTDOWN_STEP)
-                remaining -= COUNTDOWN_STEP
-                _uiState.update { it.copy(timeRemaining = remaining) }
-            }
-            if (!_uiState.value.isReadyForNext && !_uiState.value.isGameOver) {
-                currentChallenge?.let { handleFailure(it) }
-            }
         }
     }
 
@@ -157,15 +128,12 @@ class SequenceCompleteViewModel @Inject constructor(
                 ruleDescription = challenge.ruleDescription,
                 revealedAnswer = challenge.answer,
                 visibleSequence = revealSequence(challenge),
-                isReadyForNext = true,
-                timeRemaining = timerLength,
-                totalTime = timerLength
+                isReadyForNext = true
             )
         }
     }
 
     private fun handleFailure(challenge: SequenceChallenge) {
-        timerJob?.cancel()
         val remainingLives = _uiState.value.lives - 1
         _uiState.update {
             it.copy(
@@ -174,8 +142,7 @@ class SequenceCompleteViewModel @Inject constructor(
                 ruleDescription = challenge.ruleDescription,
                 revealedAnswer = challenge.answer,
                 visibleSequence = revealSequence(challenge),
-                isReadyForNext = remainingLives > 0,
-                timeRemaining = 0L
+                isReadyForNext = remainingLives > 0
             )
         }
 
@@ -188,12 +155,10 @@ class SequenceCompleteViewModel @Inject constructor(
         val nextLevel = currentLevel + 1
         val nextChallengesPerLevel = (SequenceCompleteUiState.INITIAL_CHALLENGES_PER_LEVEL + (nextLevel / 2)).coerceAtMost(MAX_CHALLENGES_PER_LEVEL)
         challengesPerLevelInternal = nextChallengesPerLevel
-        timerLength = (SequenceCompleteUiState.INITIAL_TIMER_LENGTH - nextLevel * TIMER_DECREASE_PER_LEVEL).coerceAtLeast(MIN_TIMER_LENGTH)
         return nextLevel to nextChallengesPerLevel
     }
 
     private fun onGameOver() {
-        timerJob?.cancel()
         _uiState.update { it.copy(isGameOver = true, isReadyForNext = false) }
         persistScoreIfNeeded()
     }
@@ -229,10 +194,7 @@ class SequenceCompleteViewModel @Inject constructor(
     }
 
     companion object {
-        private const val SCORE_INCREMENT = 25
-        private const val COUNTDOWN_STEP = 1_000L
-        private const val TIMER_DECREASE_PER_LEVEL = 500L
-        private const val MIN_TIMER_LENGTH = 12_000L
+        private const val SCORE_INCREMENT = 10
         private const val MAX_VALUE = 9_999
         private const val BASE_SEQUENCE_LENGTH = 4
         private const val MAX_SEQUENCE_LENGTH = 6
@@ -242,6 +204,6 @@ class SequenceCompleteViewModel @Inject constructor(
         private const val BASE_START_MAX = 15
         private const val START_GROWTH = 12
         private const val MAX_START_VALUE = 5_000
-        private const val MAX_CHALLENGES_PER_LEVEL = 12
+        private const val MAX_CHALLENGES_PER_LEVEL = 10
     }
 }

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_home/data/local/GamesStaticData.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_home/data/local/GamesStaticData.kt
@@ -64,6 +64,10 @@ val gamesDefinitionsList = listOf(
         // descriptionRes = R.string.random_operations_description,
     ),
     GameDefinition(
+        id = "sequence_complete",
+        titleRes = R.string.game_card_sequence_complete_text,
+    ),
+    GameDefinition(
         id = "double",
         titleRes = R.string.game_card_double_number_title , // R.string.double_number_title,
         // descriptionRes = R.string.double_number_description,

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_home/domain/model/GameTypes.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_home/domain/model/GameTypes.kt
@@ -66,6 +66,10 @@ enum class GameTypes(
     RANDOM_OPERATION(
         id = "random",
         scoreField = { it.random_op_game_score }
+    ),
+    SEQUENCE_COMPLETE(
+        id = "sequence_complete",
+        scoreField = { it.sequence_complete_game_score }
     );
 
     companion object {

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_home/domain/use_cases/GetGameScoresUseCase.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_home/domain/use_cases/GetGameScoresUseCase.kt
@@ -26,7 +26,8 @@ class GetGameScoresUseCase @Inject constructor(
         mix_write_result_game_score = 0,
         random_op_game_score = 0,
         count_objects_game_score = 0,
-        number_order_game_score = 0
+        number_order_game_score = 0,
+        sequence_complete_game_score = 0
     )
 
     suspend operator fun invoke(): Flow<GameScores> {

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_home/presentation/ui/HomeScreen.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_home/presentation/ui/HomeScreen.kt
@@ -187,6 +187,14 @@ fun HomeScreen(
                                     )
                                 }
 
+                                GameTypes.SEQUENCE_COMPLETE -> {
+                                    navController.navigate(
+                                        ScreenRoutes.SequenceCompleteGame.createRoute(
+                                            highScore = game.highScore ?: 0
+                                        )
+                                    )
+                                }
+
                                 null -> navController.navigate(ScreenRoutes.Home.route)
                             }
                         },
@@ -197,6 +205,5 @@ fun HomeScreen(
         }
     }
 }
-
 
 

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_statistics/data/local/db/MathBrainerDatabase.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_statistics/data/local/db/MathBrainerDatabase.kt
@@ -15,7 +15,7 @@ import eu.indiewalkabout.mathbrainer.feat_statistics.domain.model.GameStatistics
         GameStatistics::class,
         MathWriteGameStats::class
     ],
-    version = 3,
+    version = 4,
     exportSchema = true
 )
 @TypeConverters(DateConverter::class)

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_statistics/domain/model/GameScores.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_statistics/domain/model/GameScores.kt
@@ -21,7 +21,8 @@ data class GameScores(
     val mix_write_result_game_score: Int,
     val random_op_game_score: Int,
     val count_objects_game_score: Int,
-    val number_order_game_score: Int
+    val number_order_game_score: Int,
+    val sequence_complete_game_score: Int
 ){
     companion object {
         val emptyScores = GameScores(
@@ -39,7 +40,8 @@ data class GameScores(
             mix_write_result_game_score = 0,
             random_op_game_score = 0,
             count_objects_game_score = 0,
-            number_order_game_score = 0
+            number_order_game_score = 0,
+            sequence_complete_game_score = 0
         )
     }
 }

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_statistics/presentation/ui/StatisticScreen.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_statistics/presentation/ui/StatisticScreen.kt
@@ -159,7 +159,16 @@ fun StatisticScreen(
                                     )
                                 }
 
+                                GameTypes.SEQUENCE_COMPLETE -> {
+                                    navController.navigate(
+                                        ScreenRoutes.SequenceCompleteGame.createRoute(
+                                            highScore = game.highScore ?: 0
+                                        )
+                                    )
+                                }
+
                                 null -> navController.navigate(ScreenRoutes.Home.route)
+
                             }
                         }
                     )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,6 +44,8 @@
     <string name="double_number_description">Double the number as quickly as you can.</string>
     <string name="number_order_title">Number Order</string>
     <string name="number_order_description">Order the numbers correctly.</string>
+    <string name="sequence_complete_title">Sequence Solver</string>
+    <string name="sequence_complete_description">Complete the sequence by finding the missing number.</string>
     <string name="random_operations_title">Random Operations</string>
     <string name="random_operations_description">Solve random math operations.</string>
     <string name="random_operations_subtitle">Choose the operation that makes the equation true.</string>
@@ -112,6 +114,14 @@
     <string name="game_card_write_result_mult_text" >   x    \n        </string>
     <string name="game_card_write_result_div_text"  >   :    \n        </string>
     <string name="game_card_double_number_title"    >   2x   \n        </string>
+    <string name="game_card_sequence_complete_text" >1  2  4  ?\n        </string>
+
+    <string name="sequence_rule_reveal">Rule: %1$s</string>
+    <string name="sequence_correct_answer">Missing number: %1$d</string>
+    <string name="sequence_prompt">Fill the missing number to finish the sequence.</string>
+    <string name="sequence_again">Again</string>
+    <string name="sequence_feedback_success">Correct! Keep the sequences coming.</string>
+    <string name="sequence_feedback_failure">Sequence broken. See the rule and try the next one.</string>
 
 
     <!-- - - - - - - - - - - - - - - - - Dialogs Strings - - - - - - - - - - - - - - - - - - - - -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,12 +120,12 @@
     <string name="sequence_correct_answer">Missing number: %1$d</string>
     <string name="sequence_prompt">Fill the missing number to finish the sequence.</string>
     <string name="sequence_again">Again</string>
-    <string name="sequence_feedback_success">Correct! Keep the sequences coming.</string>
-    <string name="sequence_feedback_failure">Sequence broken. See the rule and try the next one.</string>
+    <string name="sequence_feedback_success">OK ! Try next.</string>
+    <string name="sequence_feedback_failure">Wrong…check rule and try the next one.</string>
 
 
     <!-- - - - - - - - - - - - - - - - - Dialogs Strings - - - - - - - - - - - - - - - - - - - - -->
-    <string name="wrong_str">Wrong...</string>
+    <string name="wrong_str">Wrong…</string>
     <string name="ok_str">OK !</string>
     <string name="next_str">Next</string>
     <string name="gameover_str">GAME OVER !</string>


### PR DESCRIPTION
## Summary
- add the new sequence completion gameplay flow with UI, state, and navigation entry points
- support persistence by extending the game scores table and home/statistics mappings
- include assets, copy, and home screen card for launching the new mode

## Testing
- `./gradlew test` *(fails: Android SDK not provisioned in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942c3764bd0832a9d7f3ce934cd1b8c)