### PR TITLE
Add Falling Ops game: view, viewmodel, generator use-case, UI and stats integration

### DIFF
--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/data/repository/MathBrainerRepository.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/data/repository/MathBrainerRepository.kt
@@ -55,6 +55,7 @@ class MathBrainerRepository private constructor(private val mathBrainerDB: MathB
         game_results_list.add("random_op_game_score")
         game_results_list.add("count_objects_game_score")
         game_results_list.add("number_order_game_score")
+        game_results_list.add("falling_ops_game_score")
     }
 
     // Check if game results are initialized (present with  0, so ok), otherwise init them.

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/domain/model/results/GameResult.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/domain/model/results/GameResult.kt
@@ -25,6 +25,7 @@ import androidx.room.PrimaryKey
  * - random_op_game_score
  * - count_objects_game_score
  * - number_order_game_score
+ * - falling_ops_game_score
  * - operations_executed
  * - operations_ok
  * - operations_ko

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/domain/usecase/GenerateFallingOperationUseCase.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/domain/usecase/GenerateFallingOperationUseCase.kt
@@ -1,0 +1,72 @@
+package eu.indiewalkabout.mathbrainer.domain.usecase
+
+import kotlin.math.min
+import kotlin.random.Random
+
+class GenerateFallingOperationUseCase(
+    private val random: Random = Random
+) {
+    data class OperationData(
+        val expression: String,
+        val result: Int,
+        val operator: Char
+    )
+
+    fun execute(level: Int): OperationData {
+        val maxOperand = maxOperandForLevel(level)
+        val operator = OPERATORS[random.nextInt(OPERATORS.size)]
+
+        return when (operator) {
+            '+' -> {
+                val left = randomOperand(maxOperand)
+                val right = randomOperand(maxOperand)
+                OperationData("$left + $right", left + right, operator)
+            }
+            '-' -> {
+                val left = randomOperand(maxOperand)
+                val right = randomOperand(left.coerceAtLeast(1))
+                OperationData("$left - $right", left - right, operator)
+            }
+            '*' -> {
+                val left = randomOperand(maxOperand)
+                val right = randomOperand(maxOperand)
+                OperationData("$left × $right", left * right, operator)
+            }
+            '/' -> {
+                val divisor = randomOperand(maxOperand.coerceAtLeast(1))
+                val quotient = randomOperand(maxOperand)
+                val dividend = divisor * quotient
+                OperationData("$dividend ÷ $divisor", quotient, operator)
+            }
+            else -> {
+                val left = randomOperand(maxOperand)
+                val right = randomOperand(maxOperand)
+                OperationData("$left + $right", left + right, '+')
+            }
+        }
+    }
+
+    fun requiredExplosionsForLevel(level: Int): Int {
+        return 6 + (level - 1) * 2
+    }
+
+    fun fallSpeedForLevel(level: Int): Float {
+        return min(3.5f + level * 0.55f, 12f)
+    }
+
+    fun spawnIntervalForLevel(level: Int): Long {
+        return maxOf(350L, 1200L - level * 60L)
+    }
+
+    fun maxOperandForLevel(level: Int): Int {
+        return min(9 + level * 4, 99)
+    }
+
+    private fun randomOperand(maxOperand: Int): Int {
+        return random.nextInt(1, maxOperand + 1)
+    }
+
+    companion object {
+        private val OPERATORS = charArrayOf('+', '-', '*', '/')
+    }
+}

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/presentation/games/customviews/FallingOperationsView.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/presentation/games/customviews/FallingOperationsView.kt
@@ -1,0 +1,70 @@
+package eu.indiewalkabout.mathbrainer.presentation.games.customviews
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.RectF
+import android.util.AttributeSet
+import android.view.View
+import androidx.core.content.ContextCompat
+import eu.indiewalkabout.mathbrainer.R
+import eu.indiewalkabout.mathbrainer.presentation.games.othergames.model.FallingOperation
+
+class FallingOperationsView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : View(context, attrs, defStyleAttr) {
+
+    private val rectPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = ContextCompat.getColor(context, R.color.background_gray_03)
+        style = Paint.Style.FILL
+    }
+
+    private val strokePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = ContextCompat.getColor(context, R.color.colorAccent)
+        style = Paint.Style.STROKE
+        strokeWidth = dpToPx(2f)
+    }
+
+    private val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = ContextCompat.getColor(context, R.color.colorAccent)
+        textSize = dpToPx(18f)
+        textAlign = Paint.Align.CENTER
+    }
+
+    private val rectRadius = dpToPx(10f)
+    private val rectWidth = dpToPx(120f)
+    private val rectHeight = dpToPx(56f)
+
+    private var operations: List<FallingOperation> = emptyList()
+
+    fun updateOperations(newOperations: List<FallingOperation>) {
+        operations = newOperations
+        invalidate()
+    }
+
+    fun operationWidth(): Float = rectWidth
+
+    fun operationHeight(): Float = rectHeight
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        operations.forEach { operation ->
+            val rect = RectF(
+                operation.x,
+                operation.y,
+                operation.x + rectWidth,
+                operation.y + rectHeight
+            )
+            canvas.drawRoundRect(rect, rectRadius, rectRadius, rectPaint)
+            canvas.drawRoundRect(rect, rectRadius, rectRadius, strokePaint)
+            val textY = operation.y + rectHeight / 2f - (textPaint.descent() + textPaint.ascent()) / 2f
+            canvas.drawText(operation.expression, operation.x + rectWidth / 2f, textY, textPaint)
+        }
+    }
+
+    private fun dpToPx(dp: Float): Float {
+        return dp * resources.displayMetrics.density
+    }
+}

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/presentation/games/othergames/FallingOperationsActivity.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/presentation/games/othergames/FallingOperationsActivity.kt
@@ -1,30 +1,249 @@
 package eu.indiewalkabout.mathbrainer.presentation.games.othergames
 
+import android.content.Intent
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.text.InputType
+import android.view.View
+import android.view.inputmethod.EditorInfo
+import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
+import androidx.lifecycle.ViewModelProvider
 import com.unity3d.services.banners.BannerView
 import com.unity3d.services.banners.UnityBannerSize
 import eu.indiewalkabout.mathbrainer.R
 import eu.indiewalkabout.mathbrainer.core.unityads.bannerListener
+import eu.indiewalkabout.mathbrainer.core.util.GameOverDialog
+import eu.indiewalkabout.mathbrainer.core.util.IGameFunctions
+import eu.indiewalkabout.mathbrainer.core.util.MyKeyboard
 import eu.indiewalkabout.mathbrainer.databinding.ActivityFallingOperationsBinding
+import eu.indiewalkabout.mathbrainer.domain.model.results.Results
+import eu.indiewalkabout.mathbrainer.presentation.games.othergames.model.FallingOperation
+import eu.indiewalkabout.mathbrainer.presentation.ui.ChooseGameActivity
 
-// TODO : to be implemented
-class FallingOperationsActivity : AppCompatActivity() {
+class FallingOperationsActivity : AppCompatActivity(), IGameFunctions {
     private lateinit var binding: ActivityFallingOperationsBinding
+    private lateinit var viewModel: FallingOperationsViewModel
+    private lateinit var livesValueIv: ArrayList<ImageView>
+    private lateinit var keyboard: MyKeyboard
+    private lateinit var gameOverDialog: GameOverDialog
+
+    private val handler = Handler(Looper.getMainLooper())
+    private var lastSpawnTime = 0L
+    private var isRunning = false
+
     private var bottomBanner: BannerView? = null
+
+    private val gameLoop = object : Runnable {
+        override fun run() {
+            if (!isRunning) return
+            val now = System.currentTimeMillis()
+            if (lastSpawnTime == 0L) {
+                lastSpawnTime = now
+            }
+            val rectWidth = binding.fallingOpsView.operationWidth()
+            val rectHeight = binding.fallingOpsView.operationHeight()
+            if (now - lastSpawnTime >= viewModel.spawnIntervalMs()) {
+                viewModel.addOperation(binding.fallingOpsView.width, rectWidth, -rectHeight)
+                lastSpawnTime = now
+            }
+            val hitBottom = viewModel.advancePositions(rectHeight, binding.fallingOpsView.height.toFloat())
+            if (hitBottom) {
+                Results.incrementGameResultsThread("lives_missed")
+                if (viewModel.lives.value == 0) {
+                    endGame()
+                    return
+                }
+            }
+            handler.postDelayed(this, FRAME_DELAY)
+        }
+    }
+
+    override val isGameOver: Boolean
+        get() = viewModel.lives.value == 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // setContentView(R.layout.activity_falling_operations)
         binding = DataBindingUtil.setContentView(this, R.layout.activity_falling_operations)
 
-        // You have to pass the AdRequest from ConsentSDK.getAdRequest(this) because it handle the right way to load the ad
-        // binding.mAdView.loadAd(getAdRequest(this@FallingOperationsActivity))
+        viewModel = ViewModelProvider(this).get(FallingOperationsViewModel::class.java)
+
+        livesValueIv = arrayListOf(
+            findViewById(R.id.life_01_iv),
+            findViewById(R.id.life_02_iv),
+            findViewById(R.id.life_03_iv)
+        )
+
+        setupCustomKeyboard()
+        setupObservers()
+        showHighscore()
+
+        binding.backhomeImg.setOnClickListener {
+            isComingHome()
+            startActivity(Intent(this@FallingOperationsActivity, ChooseGameActivity::class.java))
+        }
 
         bottomBanner = BannerView(this, "banner", UnityBannerSize(320, 50))
         bottomBanner?.listener = bannerListener
         bottomBanner?.load()
         binding.bannerLayout.addView(bottomBanner)
+
+        hideStatusNavBars()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        hideStatusNavBars()
+        startGameLoop()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        stopGameLoop()
+    }
+
+    private fun setupObservers() {
+        viewModel.level.observe(this) { level ->
+            binding.levelValueTv.text = level.toString()
+        }
+        viewModel.score.observe(this) { score ->
+            binding.scoreValueTv.text = score.toString()
+        }
+        viewModel.lives.observe(this) { lives ->
+            livesValueIv.forEachIndexed { index, imageView ->
+                imageView.visibility = if (index < lives) View.VISIBLE else View.INVISIBLE
+            }
+        }
+        viewModel.progress.observe(this) { progress ->
+            binding.countdownBar.progress = progress
+        }
+        viewModel.progressTarget.observe(this) { target ->
+            binding.countdownBar.max = target
+        }
+        viewModel.operationsState.observe(this) { operations ->
+            binding.fallingOpsView.updateOperations(operations)
+        }
+    }
+
+    private fun showHighscore() {
+        val intent = intent
+        val highscore = if (intent.hasExtra(ChooseGameActivity.HIGHSCORE)) {
+            intent.getIntExtra(ChooseGameActivity.HIGHSCORE, 0)
+        } else {
+            0
+        }
+        binding.highscoreValueTv.text = highscore.toString()
+    }
+
+    private fun setupCustomKeyboard() {
+        keyboard = findViewById(R.id.keyboard)
+
+        binding.playerInputEt.setOnTouchListener { _, event ->
+            val inType = binding.playerInputEt.inputType
+            binding.playerInputEt.inputType = InputType.TYPE_NULL
+            binding.playerInputEt.onTouchEvent(event)
+            binding.playerInputEt.inputType = inType
+            binding.playerInputEt.setTextIsSelectable(false)
+            true
+        }
+
+        val ic = binding.playerInputEt.onCreateInputConnection(EditorInfo())
+        keyboard.setInputConnection(ic, this@FallingOperationsActivity)
+    }
+
+    private fun startGameLoop() {
+        if (isRunning) return
+        isRunning = true
+        binding.fallingOpsView.post {
+            lastSpawnTime = 0L
+            handler.post(gameLoop)
+        }
+    }
+
+    private fun stopGameLoop() {
+        isRunning = false
+        handler.removeCallbacks(gameLoop)
+    }
+
+    private fun endGame() {
+        stopGameLoop()
+        Results.incrementGameResultsThread("games_played")
+        Results.incrementGameResultsThread("games_lose")
+        Results.updateGameResultHighscoreThread("falling_ops_game_score", viewModel.score.value ?: 0)
+        Results.incrementGameResultByDeltaThread("global_score", viewModel.score.value ?: 0)
+        gameOverDialog = GameOverDialog(this, this@FallingOperationsActivity, this)
+    }
+
+    private fun isComingHome() {
+        Results.updateGameResultHighscoreThread("falling_ops_game_score", viewModel.score.value ?: 0)
+        Results.incrementGameResultByDeltaThread("global_score", viewModel.score.value ?: 0)
+    }
+
+    private fun recordOperationStats(removed: List<FallingOperation>) {
+        val sums = removed.count { it.operator == '+' }
+        val differences = removed.count { it.operator == '-' }
+        val multiplications = removed.count { it.operator == '*' }
+        val divisions = removed.count { it.operator == '/' }
+        if (sums > 0) {
+            Results.incrementGameResultByDeltaThread("sums", sums)
+        }
+        if (differences > 0) {
+            Results.incrementGameResultByDeltaThread("differences", differences)
+        }
+        if (multiplications > 0) {
+            Results.incrementGameResultByDeltaThread("multiplications", multiplications)
+        }
+        if (divisions > 0) {
+            Results.incrementGameResultByDeltaThread("divisions", divisions)
+        }
+    }
+
+    override fun updateProgressBar(progress: Int) {
+        binding.countdownBar.progress = progress
+    }
+
+    override fun newChallenge() {
+        val rectWidth = binding.fallingOpsView.operationWidth()
+        val rectHeight = binding.fallingOpsView.operationHeight()
+        viewModel.addOperation(binding.fallingOpsView.width, rectWidth, -rectHeight)
+    }
+
+    override fun checkPlayerInput() {
+        val input = binding.playerInputEt.text.toString()
+        if (input.isEmpty()) {
+            return
+        }
+        val value = input.toIntOrNull() ?: return
+        val result = viewModel.consumeInput(value)
+        Results.incrementGameResultsThread("operations_executed")
+        if (result.matched) {
+            Results.incrementGameResultsThread("operations_ok")
+            recordOperationStats(result.removedOperations)
+            if (result.leveledUp) {
+                Results.incrementGameResultsThread("level_upgrades")
+            }
+        } else {
+            Results.incrementGameResultsThread("operations_ko")
+        }
+        binding.playerInputEt.text.clear()
+    }
+
+    override fun checkCountdownExpired() {
+    }
+
+    private fun hideStatusNavBars() {
+        val decorView = window.decorView
+        val uiOptions = (
+            View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+                or View.SYSTEM_UI_FLAG_FULLSCREEN
+            )
+        decorView.systemUiVisibility = uiOptions
+    }
+
+    companion object {
+        private const val FRAME_DELAY = 16L
     }
 }

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/presentation/games/othergames/FallingOperationsViewModel.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/presentation/games/othergames/FallingOperationsViewModel.kt
@@ -1,0 +1,134 @@
+package eu.indiewalkabout.mathbrainer.presentation.games.othergames
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import eu.indiewalkabout.mathbrainer.domain.usecase.GenerateFallingOperationUseCase
+import eu.indiewalkabout.mathbrainer.presentation.games.othergames.model.FallingOperation
+
+class FallingOperationsViewModel(
+    private val generator: GenerateFallingOperationUseCase = GenerateFallingOperationUseCase()
+) : ViewModel() {
+    private val operations = mutableListOf<FallingOperation>()
+
+    private val _level = MutableLiveData(1)
+    val level: LiveData<Int> = _level
+
+    private val _score = MutableLiveData(0)
+    val score: LiveData<Int> = _score
+
+    private val _lives = MutableLiveData(3)
+    val lives: LiveData<Int> = _lives
+
+    private val _progress = MutableLiveData(0)
+    val progress: LiveData<Int> = _progress
+
+    private val _progressTarget = MutableLiveData(generator.requiredExplosionsForLevel(1))
+    val progressTarget: LiveData<Int> = _progressTarget
+
+    private val _operationsState = MutableLiveData<List<FallingOperation>>(emptyList())
+    val operationsState: LiveData<List<FallingOperation>> = _operationsState
+
+    private var clearedThisLevel = 0
+
+    fun currentOperations(): List<FallingOperation> = operations
+
+    fun fallSpeed(): Float = generator.fallSpeedForLevel(currentLevel())
+
+    fun spawnIntervalMs(): Long = generator.spawnIntervalForLevel(currentLevel())
+
+    fun addOperation(viewWidth: Int, rectWidth: Float, startOffset: Float) {
+        if (viewWidth <= rectWidth) return
+        val data = generator.execute(currentLevel())
+        val maxX = (viewWidth - rectWidth).toInt().coerceAtLeast(1)
+        val x = (0 until maxX).random().toFloat()
+        val operation = FallingOperation(
+            expression = data.expression,
+            result = data.result,
+            operator = data.operator,
+            x = x,
+            y = startOffset
+        )
+        operations.add(operation)
+        _operationsState.value = operations.toList()
+    }
+
+    fun advancePositions(rectHeight: Float, viewHeight: Float): Boolean {
+        if (operations.isEmpty()) return false
+        val delta = fallSpeed()
+        var hitBottom = false
+        operations.forEach { it.y += delta }
+        if (operations.any { it.y + rectHeight >= viewHeight }) {
+            hitBottom = true
+            operations.clear()
+            _operationsState.value = operations.toList()
+            loseLife()
+        }
+        if (!hitBottom) {
+            _operationsState.value = operations.toList()
+        }
+        return hitBottom
+    }
+
+    fun consumeInput(inputValue: Int): InputResult {
+        val matches = operations.filter { it.result == inputValue }
+        if (matches.isEmpty()) {
+            return InputResult(false, emptyList(), false)
+        }
+        operations.removeAll(matches.toSet())
+        val newScore = (_score.value ?: 0) + matches.size
+        _score.value = newScore
+        clearedThisLevel += matches.size
+        _progress.value = clearedThisLevel
+        _operationsState.value = operations.toList()
+
+        var leveledUp = false
+        if (clearedThisLevel >= currentTarget()) {
+            levelUp()
+            leveledUp = true
+        }
+        return InputResult(true, matches, leveledUp)
+    }
+
+    fun resetInputProgress() {
+        _progress.value = clearedThisLevel
+    }
+
+    fun resetGame() {
+        operations.clear()
+        _operationsState.value = operations.toList()
+        _level.value = 1
+        _score.value = 0
+        _lives.value = 3
+        clearedThisLevel = 0
+        _progress.value = 0
+        _progressTarget.value = generator.requiredExplosionsForLevel(1)
+    }
+
+    private fun levelUp() {
+        operations.clear()
+        _operationsState.value = operations.toList()
+        clearedThisLevel = 0
+        _progress.value = 0
+        val nextLevel = currentLevel() + 1
+        _level.value = nextLevel
+        _progressTarget.value = generator.requiredExplosionsForLevel(nextLevel)
+    }
+
+    private fun loseLife() {
+        val livesLeft = (currentLives() - 1).coerceAtLeast(0)
+        _lives.value = livesLeft
+    }
+
+    private fun currentLevel(): Int = _level.value ?: 1
+
+    private fun currentLives(): Int = _lives.value ?: 3
+
+    private fun currentTarget(): Int = _progressTarget.value ?: generator.requiredExplosionsForLevel(currentLevel())
+
+    data class InputResult(
+        val matched: Boolean,
+        val removedOperations: List<FallingOperation>,
+        val leveledUp: Boolean
+    )
+}

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/presentation/games/othergames/model/FallingOperation.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/presentation/games/othergames/model/FallingOperation.kt
@@ -1,0 +1,9 @@
+package eu.indiewalkabout.mathbrainer.presentation.games.othergames.model
+
+data class FallingOperation(
+    val expression: String,
+    val result: Int,
+    val operator: Char,
+    var x: Float,
+    var y: Float
+)

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/presentation/ui/ChooseGameActivity.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/presentation/ui/ChooseGameActivity.kt
@@ -22,6 +22,7 @@ import eu.indiewalkabout.mathbrainer.presentation.games.arithmetic.Math_Op_Choos
 import eu.indiewalkabout.mathbrainer.presentation.games.arithmetic.Math_Op_Write_Result_Activity
 import eu.indiewalkabout.mathbrainer.presentation.games.arithmetic.RandomOperationActivity
 import eu.indiewalkabout.mathbrainer.presentation.games.othergames.CountObjectsActivity
+import eu.indiewalkabout.mathbrainer.presentation.games.othergames.FallingOperationsActivity
 import eu.indiewalkabout.mathbrainer.presentation.games.othergames.NumberOrderActivity
 
 // Choose the type of game
@@ -44,6 +45,7 @@ class ChooseGameActivity : AppCompatActivity() {
     private var randomOpsHighscore_value: Int = 0
     private var quickCountHighscore_value: Int = 0
     private var orderHighscore_value: Int = 0
+    private var fallingOpsHighscore_value: Int = 0
 
     // private lateinit var consentSDK: ConsentSDK
     private var bottomBanner: BannerView? = null
@@ -217,6 +219,12 @@ class ChooseGameActivity : AppCompatActivity() {
             startActivity(intent)
         }
 
+        binding.fallingOpsBtn.setOnClickListener {
+            val intent = Intent(this@ChooseGameActivity, FallingOperationsActivity::class.java)
+            intent.putExtra(HIGHSCORE, fallingOpsHighscore_value)
+            startActivity(intent)
+        }
+
         binding.randomOpsBtn.setOnClickListener {
             val intent = Intent(this@ChooseGameActivity, RandomOperationActivity::class.java)
             intent.putExtra(HIGHSCORE, randomOpsHighscore_value)
@@ -294,6 +302,8 @@ class ChooseGameActivity : AppCompatActivity() {
             MathBrainerUtility.getGameResultsFromList("count_objects_game_score", gameResults)
         orderHighscore_value =
             MathBrainerUtility.getGameResultsFromList("number_order_game_score", gameResults)
+        fallingOpsHighscore_value =
+            MathBrainerUtility.getGameResultsFromList("falling_ops_game_score", gameResults)
     }
 
 

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/presentation/ui/HighscoresActivity.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/presentation/ui/HighscoresActivity.kt
@@ -20,6 +20,7 @@ import eu.indiewalkabout.mathbrainer.presentation.games.arithmetic.Math_Op_Choos
 import eu.indiewalkabout.mathbrainer.presentation.games.arithmetic.Math_Op_Write_Result_Activity
 import eu.indiewalkabout.mathbrainer.presentation.games.arithmetic.RandomOperationActivity
 import eu.indiewalkabout.mathbrainer.presentation.games.othergames.CountObjectsActivity
+import eu.indiewalkabout.mathbrainer.presentation.games.othergames.FallingOperationsActivity
 import eu.indiewalkabout.mathbrainer.presentation.games.othergames.NumberOrderActivity
 
 // Choose the type of game
@@ -43,6 +44,7 @@ class HighscoresActivity : AppCompatActivity() {
     private var randomOpsHighscore_value: Int = 0
     private var quickCountHighscore_value: Int = 0
     private var orderHighscore_value: Int = 0
+    private var fallingOpsHighscore_value: Int = 0
 
     // unity bottom ads
     private var bottomBanner: BannerView? = null
@@ -177,6 +179,12 @@ class HighscoresActivity : AppCompatActivity() {
             startActivity(intent)
         }
 
+        binding.fallingOpsBtn.setOnClickListener {
+            val intent = Intent(this@HighscoresActivity, FallingOperationsActivity::class.java)
+            intent.putExtra(HIGHSCORE, fallingOpsHighscore_value)
+            startActivity(intent)
+        }
+
         binding.randomOpsBtn.setOnClickListener {
             val intent = Intent(this@HighscoresActivity, RandomOperationActivity::class.java)
             intent.putExtra(HIGHSCORE, randomOpsHighscore_value)
@@ -235,6 +243,7 @@ class HighscoresActivity : AppCompatActivity() {
 
         quickCountHighscore_value = MathBrainerUtility.getGameResultsFromList("count_objects_game_score", gameResults)
         orderHighscore_value = MathBrainerUtility.getGameResultsFromList("number_order_game_score", gameResults)
+        fallingOpsHighscore_value = MathBrainerUtility.getGameResultsFromList("falling_ops_game_score", gameResults)
 
         // set textviews
         binding.totalHighScoreTv.text = totalHighScore_value.toString()
@@ -256,6 +265,7 @@ class HighscoresActivity : AppCompatActivity() {
 
         binding.quickCountScoreTv.text = quickCountHighscore_value.toString()
         binding.orderScoreTv.text = orderHighscore_value.toString()
+        binding.fallingOpsScoreTv.text = fallingOpsHighscore_value.toString()
     }
 
     // Make bottom navigation bar and status bar hide, without resize when reappearing

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/presentation/ui/HomeGameActivity.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/presentation/ui/HomeGameActivity.kt
@@ -21,6 +21,7 @@ import eu.indiewalkabout.mathbrainer.presentation.games.arithmetic.Math_Op_Choos
 import eu.indiewalkabout.mathbrainer.presentation.games.arithmetic.Math_Op_Write_Result_Activity
 import eu.indiewalkabout.mathbrainer.presentation.games.arithmetic.RandomOperationActivity
 import eu.indiewalkabout.mathbrainer.presentation.games.othergames.CountObjectsActivity
+import eu.indiewalkabout.mathbrainer.presentation.games.othergames.FallingOperationsActivity
 import eu.indiewalkabout.mathbrainer.presentation.games.othergames.NumberOrderActivity
 
 // Choose the type of game
@@ -43,6 +44,7 @@ class HomeGameActivity : AppCompatActivity() {
     private var randomOpsHighscore_value: Int = 0
     private var quickCountHighscore_value: Int = 0
     private var orderHighscore_value: Int = 0
+    private var fallingOpsHighscore_value: Int = 0
 
     // unity bottom ads
     private var bottomBanner: BannerView? = null
@@ -216,6 +218,12 @@ class HomeGameActivity : AppCompatActivity() {
             startActivity(intent)
         }
 
+        binding.fallingOpsBtn.setOnClickListener {
+            val intent = Intent(this@HomeGameActivity, FallingOperationsActivity::class.java)
+            intent.putExtra(HIGHSCORE, fallingOpsHighscore_value)
+            startActivity(intent)
+        }
+
         binding.randomOpsBtn.setOnClickListener {
             val intent = Intent(this@HomeGameActivity, RandomOperationActivity::class.java)
             intent.putExtra(HIGHSCORE, randomOpsHighscore_value)
@@ -289,6 +297,8 @@ class HomeGameActivity : AppCompatActivity() {
             MathBrainerUtility.getGameResultsFromList("count_objects_game_score", gameResults)
         orderHighscore_value =
             MathBrainerUtility.getGameResultsFromList("number_order_game_score", gameResults)
+        fallingOpsHighscore_value =
+            MathBrainerUtility.getGameResultsFromList("falling_ops_game_score", gameResults)
     }
 
     // Make bottom navigation bar and status bar hide, without resize when reappearing

--- a/app/src/main/res/layout/activity_choose_game_new.xml
+++ b/app/src/main/res/layout/activity_choose_game_new.xml
@@ -366,6 +366,24 @@
                     android:scaleY="0.55"
                     app:srcCompat="@drawable/order_count_btn" />
 
+                <Button
+                    android:id="@+id/fallingOpsBtn"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_marginStart="4dp"
+                    android:layout_marginLeft="4dp"
+                    android:layout_marginTop="4dp"
+                    android:layout_marginEnd="4dp"
+                    android:layout_marginRight="4dp"
+                    android:layout_marginBottom="16dp"
+                    android:layout_weight="1"
+                    android:background="@drawable/rounded_rect_simplekeyboard_btn"
+                    android:fontFamily="@font/quicksand"
+                    android:text="@string/falling_ops"
+                    android:textAlignment="center"
+                    android:textColor="@color/colorAccent"
+                    android:textStyle="bold" />
+
             </TableRow>
         </TableLayout>
 

--- a/app/src/main/res/layout/activity_falling_operations.xml
+++ b/app/src/main/res/layout/activity_falling_operations.xml
@@ -10,112 +10,157 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@color/background_gray_01"
         tools:context=".presentation.games.othergames.FallingOperationsActivity">
-
 
         <ImageView
             android:id="@+id/backgroundImg"
             android:layout_width="0dp"
-            android:layout_height="836dp"
+            android:layout_height="0dp"
             android:contentDescription="@string/backgroundimg"
             android:scaleType="centerCrop"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="0.126"
             app:srcCompat="@drawable/summer" />
 
         <ProgressBar
             android:id="@+id/countdownBar"
             style="@android:style/Widget.ProgressBar.Horizontal"
             android:layout_width="match_parent"
-            android:layout_height="40dp"
-            android:max="30"
-            android:progress="100"
+            android:layout_height="32dp"
+            android:max="10"
+            android:progress="0"
             android:progressDrawable="@drawable/horizontal_progress_drawable_green"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
+        <ImageView
+            android:id="@+id/backhome_img"
+            android:layout_width="30dp"
+            android:layout_height="30dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="8dp"
+            android:background="@drawable/rounded_rect_dark_gray_btn"
+            android:padding="6dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/ic_home_white_24dp" />
 
         <TextView
             android:id="@+id/level_tv"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
+            android:layout_marginStart="12dp"
+            android:layout_marginTop="8dp"
+            android:fontFamily="@font/quicksand"
+            android:gravity="start"
             android:text="@string/level"
             android:textAlignment="viewStart"
+            android:textColor="@color/colorAccent"
+            android:textSize="16sp"
+            android:textStyle="bold"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/countdownBar"
-            android:layout_marginLeft="8dp"
-            android:gravity="start" />
+            app:layout_constraintTop_toBottomOf="@+id/countdownBar" />
 
         <TextView
             android:id="@+id/levelValue_tv"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="8dp"
+            android:layout_marginStart="6dp"
+            android:layout_marginTop="4dp"
+            android:fontFamily="@font/quicksand"
             android:text="@string/_0"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/level_tv"
-            android:layout_marginLeft="8dp" />
+            android:textColor="@color/colorAccent"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            app:layout_constraintStart_toStartOf="@+id/level_tv"
+            app:layout_constraintTop_toBottomOf="@+id/level_tv" />
 
         <TextView
             android:id="@+id/scoreLabel_tv"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:fontFamily="@font/quicksand"
             android:text="@string/score"
             android:textAlignment="viewStart"
-            app:layout_constraintEnd_toStartOf="@+id/lifeRemainText_tv"
-            app:layout_constraintHorizontal_bias="0.556"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/level_tv"
-            app:layout_constraintTop_toBottomOf="@+id/countdownBar"
-            android:gravity="start" />
+            android:textColor="@color/colorAccent"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            app:layout_constraintStart_toEndOf="@+id/levelValue_tv"
+            app:layout_constraintTop_toBottomOf="@+id/countdownBar" />
 
         <TextView
             android:id="@+id/scoreValue_tv"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="8dp"
+            android:layout_marginStart="6dp"
+            android:layout_marginTop="4dp"
+            android:fontFamily="@font/quicksand"
             android:text="@string/_0"
-            app:layout_constraintEnd_toStartOf="@+id/gridLayout"
-            app:layout_constraintHorizontal_bias="0.542"
-            app:layout_constraintStart_toEndOf="@+id/levelValue_tv"
+            android:textColor="@color/colorAccent"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            app:layout_constraintStart_toStartOf="@+id/scoreLabel_tv"
             app:layout_constraintTop_toBottomOf="@+id/scoreLabel_tv" />
 
         <TextView
+            android:id="@+id/highscoreLabel_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:fontFamily="@font/quicksand"
+            android:text="@string/highscore_label"
+            android:textAlignment="viewStart"
+            android:textColor="@android:color/holo_green_light"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            app:layout_constraintStart_toEndOf="@+id/scoreValue_tv"
+            app:layout_constraintTop_toBottomOf="@+id/countdownBar" />
+
+        <TextView
+            android:id="@+id/highscoreValue_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="6dp"
+            android:layout_marginTop="4dp"
+            android:fontFamily="@font/quicksand"
+            android:text="@string/_0"
+            android:textColor="@android:color/holo_green_light"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            app:layout_constraintStart_toStartOf="@+id/highscoreLabel_tv"
+            app:layout_constraintTop_toBottomOf="@+id/highscoreLabel_tv" />
+
+        <TextView
             android:id="@+id/lifeRemainText_tv"
-            android:layout_width="36dp"
-            android:layout_height="19dp"
-            android:layout_marginEnd="60dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="12dp"
+            android:fontFamily="@font/quicksand"
             android:gravity="center_vertical"
             android:text="@string/lives"
-            android:textAlignment="center"
+            android:textColor="@color/colorAccent"
+            android:textSize="14sp"
+            android:textStyle="bold"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/countdownBar"
-            android:layout_marginRight="60dp" />
-
+            app:layout_constraintTop_toBottomOf="@+id/countdownBar" />
 
         <GridLayout
             android:id="@+id/gridLayout"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="16dp"
-            android:layout_marginRight="16dp"
-            android:layout_marginTop="8dp"
-            android:layout_weight="1"
+            android:layout_marginTop="4dp"
+            android:layout_marginEnd="12dp"
             android:columnCount="3"
             android:rowCount="1"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/lifeRemainText_tv">
 
             <ImageView
@@ -123,55 +168,83 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:contentDescription="@string/todo"
-                app:layout_constraintTop_toTopOf="parent"
-                app:srcCompat="@android:drawable/presence_online"
-                tools:layout_editor_absoluteX="301dp" />
+                app:srcCompat="@android:drawable/presence_online" />
 
             <ImageView
                 android:id="@+id/life_02_iv"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginEnd="8dp"
-                android:layout_marginStart="8dp"
+                android:layout_marginStart="6dp"
+                android:layout_marginEnd="6dp"
                 android:contentDescription="@string/todo"
-                app:layout_constraintEnd_toStartOf="@+id/life_03_iv"
-                app:layout_constraintStart_toEndOf="@+id/life_01_iv"
-                app:layout_constraintTop_toTopOf="parent"
                 app:srcCompat="@android:drawable/presence_online" />
 
             <ImageView
                 android:id="@+id/life_03_iv"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginEnd="16dp"
-                android:layout_marginRight="16dp"
                 android:contentDescription="@string/todo"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
                 app:srcCompat="@android:drawable/presence_online" />
         </GridLayout>
 
+        <eu.indiewalkabout.mathbrainer.presentation.games.customviews.FallingOperationsView
+            android:id="@+id/fallingOpsView"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toTopOf="@+id/inputLabel_tv"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/scoreValue_tv" />
 
-        <!-- - - - - QUIZ SECTION - - - - - - - - - - - - - - - - - - -->
+        <TextView
+            android:id="@+id/inputLabel_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:fontFamily="@font/quicksand"
+            android:text="@string/your_answer"
+            android:textColor="@color/colorAccent"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/fallingOpsView" />
 
+        <EditText
+            android:id="@+id/playerInput_et"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:cursorVisible="false"
+            android:ems="8"
+            android:focusable="false"
+            android:focusableInTouchMode="true"
+            android:fontFamily="@font/quicksand"
+            android:gravity="center_vertical"
+            android:imeOptions="actionDone"
+            android:inputType="number"
+            android:maxLength="6"
+            android:singleLine="true"
+            android:textAlignment="center"
+            android:textColor="@color/colorAccent"
+            android:textSize="22sp"
+            android:textStyle="bold"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/inputLabel_tv" />
 
-        <!-- Sample AdMob banner ID       : ca-app-pub-3940256099942544/6300978111 -->
-        <!-- THIS APP REAL AdMob banner ID: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
-        <!--<com.google.android.gms.ads.AdView xmlns:ads="http://schemas.android.com/apk/res-auto"
-            android:id="@+id/mAdView"
-            android:layout_width="match_parent"
-            android:layout_height="49dp"
-            android:layout_alignParentBottom="true"
-            android:layout_centerHorizontal="true"
-            android:layout_marginStart="8dp"
-            android:layout_marginEnd="8dp"
-            ads:adSize="BANNER"
-            ads:adUnitId="@string/admob_key_bottom_banner"
-            ads:layout_constraintBottom_toBottomOf="parent"
-            ads:layout_constraintEnd_toEndOf="parent"
-            ads:layout_constraintHorizontal_bias="0.0"
-            ads:layout_constraintStart_toStartOf="parent"></com.google.android.gms.ads.AdView>-->
+        <eu.indiewalkabout.mathbrainer.core.util.MyKeyboard
+            android:id="@+id/keyboard"
+            android:layout_width="300dp"
+            android:layout_height="182dp"
+            android:layout_marginStart="32dp"
+            android:layout_marginEnd="32dp"
+            android:layout_marginTop="12dp"
+            android:orientation="vertical"
+            app:layout_constraintBottom_toTopOf="@+id/bannerLayout"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/playerInput_et" />
 
         <RelativeLayout
             android:id="@+id/bannerLayout"
@@ -185,7 +258,6 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
-
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/activity_highscores.xml
+++ b/app/src/main/res/layout/activity_highscores.xml
@@ -552,6 +552,24 @@
                     android:scaleY="0.55"
                     app:srcCompat="@drawable/order_count_btn" />
 
+                <Button
+                    android:id="@+id/fallingOpsBtn"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_marginStart="4dp"
+                    android:layout_marginLeft="4dp"
+                    android:layout_marginTop="4dp"
+                    android:layout_marginEnd="4dp"
+                    android:layout_marginRight="4dp"
+                    android:layout_marginBottom="16dp"
+                    android:layout_weight="1"
+                    android:background="@drawable/rounded_rect_simplekeyboard_btn"
+                    android:fontFamily="@font/quicksand"
+                    android:text="@string/falling_ops"
+                    android:textAlignment="center"
+                    android:textColor="@color/colorAccent"
+                    android:textStyle="bold" />
+
             </TableRow>
 
             <TableRow
@@ -572,6 +590,18 @@
 
                 <TextView
                     android:id="@+id/orderScore_tv"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="12dp"
+                    android:layout_weight="1"
+                    android:fontFamily="@font/quicksand"
+                    android:textAlignment="center"
+                    android:textColor="@android:color/holo_green_light"
+                    android:textStyle="bold"
+                    tools:text="@string/_0" />
+
+                <TextView
+                    android:id="@+id/fallingOpsScore_tv"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="12dp"

--- a/app/src/main/res/layout/activity_home_game.xml
+++ b/app/src/main/res/layout/activity_home_game.xml
@@ -366,6 +366,24 @@
                     android:scaleY="0.55"
                     app:srcCompat="@drawable/order_count_btn" />
 
+                <Button
+                    android:id="@+id/fallingOpsBtn"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_marginStart="4dp"
+                    android:layout_marginLeft="4dp"
+                    android:layout_marginTop="4dp"
+                    android:layout_marginEnd="4dp"
+                    android:layout_marginRight="4dp"
+                    android:layout_marginBottom="16dp"
+                    android:layout_weight="1"
+                    android:background="@drawable/rounded_rect_simplekeyboard_btn"
+                    android:fontFamily="@font/quicksand"
+                    android:text="@string/falling_ops"
+                    android:textAlignment="center"
+                    android:textColor="@color/colorAccent"
+                    android:textStyle="bold" />
+
             </TableRow>
         </TableLayout>
 


### PR DESCRIPTION
### Motivation
- Implement the new "Falling Ops" game where operations (rectangles with expressions) fall toward a keypad area and the player types results to remove them.  The game needs its own screen, view-model, model/use-case for generation, keyboard integration, and statistics tracking like the other games.
- Reuse existing app patterns (custom keyboard, Results/statistics, highscore screens, navigation from home/choose) so the new game integrates with the rest of the app.

### Description
- New use-case to generate operations per level: `GenerateFallingOperationUseCase` (new). It controls operand ranges, operators (+ - * /), spawn interval, required explosions per level and falling speed.
- New domain model and UI primitives:
  - `FallingOperation` model (new) — represents an expression, result, operator and (x,y) position.
  - `FallingOperationsView` (new custom View) — draws rounded-rect operations and expression text.
  - `FallingOperationsViewModel` (new) — holds operations list, level/score/lives/progress and exposes methods to add operations, advance positions, consume typed input and handle level ups / lives.
- New game Activity: `FallingOperationsActivity` (replaced placeholder). Implements game loop (spawn + advance positions), integrates `MyKeyboard`, updates `Results` counters (operations_executed/ok/ko, sums/differences/multiplications/divisions, level_upgrades, lives_missed, games_played/games_lose, falling_ops_game_score and global_score), and shows game over dialog.
- Persisted results / highscores integration:
  - Added `falling_ops_game_score` to `GameResult` doc and initialized it in `MathBrainerRepository` list.
  - Hooked into Highscores/Home/Choose screens: added a Falling Ops entry/button and a highscores card value (`fallingOpsScore_tv`), and pass highscores via intent like other games.
- Layout updates:
  - New/updated layout `activity_falling_operations.xml` with `FallingOperationsView`, input field and keyboard.
  - Added Falling Ops buttons to `activity_home_game.xml`, `activity_choose_game_new.xml` and `activity_highscores.xml`.
- Files added/modified (high level):
  - Added: `GenerateFallingOperationUseCase.kt`, `FallingOperation.kt`, `FallingOperationsView.kt`, `FallingOperationsViewModel.kt`, updated `FallingOperationsActivity.kt` (full implementation), and several layout files updated/created.
  - Updated: repository/result model and UI activities to register the new game and track its highscore.

### Testing
- Automated tests: none were executed as part of this change (no unit or instrumentation tests were run in the rollout).
- Recommended next steps to validate locally or in CI: run `./gradlew assembleDebug` and exercise the new screen on a device/emulator; run instrumentation tests if/when added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945a8699338832ab0c9126189f3edea)