### PR TITLE
Add Enigma puzzle game mode

### DIFF
--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/core/presentation/navigation/NavGraph.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/core/presentation/navigation/NavGraph.kt
@@ -12,6 +12,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import eu.indiewalkabout.mathbrainer.feat_credits.presentation.ui.GameCreditsScreen
 import eu.indiewalkabout.mathbrainer.feat_games.feat_count_items.presentation.ui.CountObjectsGameScreen
+import eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.presentation.ui.EnigmaGameScreen
 import eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_double.presentation.ui.DoubleNumberGameScreen
 import eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_write.presentation.ui.MathWriteGameScreen
 import eu.indiewalkabout.mathbrainer.feat_games.feat_math_random_operation.presentation.ui.RandomOperationGameScreen
@@ -157,6 +158,21 @@ fun NavGraph(
             val highScore = backStackEntry.arguments?.getInt("highScore") ?: 0
 
             SequenceCompleteGameScreen(
+                initialHighScore = highScore,
+                onBack = { navController.popBackStack() }
+            )
+        }
+
+        // --- Enigma Game ---
+        composable(
+            route = ScreenRoutes.EnigmaGame.route,
+            arguments = listOf(
+                navArgument("highScore") { type = NavType.IntType }
+            )
+        ) { backStackEntry ->
+            val highScore = backStackEntry.arguments?.getInt("highScore") ?: 0
+
+            EnigmaGameScreen(
                 initialHighScore = highScore,
                 onBack = { navController.popBackStack() }
             )

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/core/presentation/navigation/ScreenRoutes.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/core/presentation/navigation/ScreenRoutes.kt
@@ -33,6 +33,9 @@ sealed class ScreenRoutes(val route: String) {
     object SequenceCompleteGame : ScreenRoutes("sequence_complete_game/{highScore}") {
         fun createRoute(highScore: Int = 0): String = "sequence_complete_game/$highScore"
     }
+    object EnigmaGame : ScreenRoutes("enigma_game/{highScore}") {
+        fun createRoute(highScore: Int = 0): String = "enigma_game/$highScore"
+    }
     object GameSettings : ScreenRoutes("game_settings")
     object GameCredits : ScreenRoutes("game_credits")
     object Statistics : ScreenRoutes("statistics")

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/core/util/OperationFormatter.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/core/util/OperationFormatter.kt
@@ -5,6 +5,7 @@ object OperationFormatter {
         return when (operation) {
             '*' -> "×"
             '/' -> ":"
+            '-' -> "–"
             else -> operation.toString()
         }
     }
@@ -13,6 +14,7 @@ object OperationFormatter {
         return when (operation) {
             "*" -> "×"
             "/" -> ":"
+            "-" -> "–"
             else -> operation
         }
     }

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/domain/model/EnigmaChallenge.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/domain/model/EnigmaChallenge.kt
@@ -1,0 +1,8 @@
+package eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.domain.model
+
+data class EnigmaChallenge(
+    val equations: List<EnigmaEquation>,
+    val finalExpression: String,
+    val answer: Int,
+    val level: Int
+)

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/domain/model/EnigmaConfig.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/domain/model/EnigmaConfig.kt
@@ -1,0 +1,7 @@
+package eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.domain.model
+
+data class EnigmaConfig(
+    val level: Int,
+    val minValue: Int = 2,
+    val maxValue: Int = 20
+)

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/domain/model/EnigmaEquation.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/domain/model/EnigmaEquation.kt
@@ -1,0 +1,6 @@
+package eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.domain.model
+
+data class EnigmaEquation(
+    val leftExpression: String,
+    val result: Int
+)

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/domain/use_cases/GenerateEnigmaChallengeUseCase.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/domain/use_cases/GenerateEnigmaChallengeUseCase.kt
@@ -1,0 +1,164 @@
+package eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.domain.use_cases
+
+import eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.domain.model.EnigmaChallenge
+import eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.domain.model.EnigmaConfig
+import eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.domain.model.EnigmaEquation
+import javax.inject.Inject
+import kotlin.math.max
+import kotlin.random.Random
+
+class GenerateEnigmaChallengeUseCase @Inject constructor() {
+
+    operator fun invoke(config: EnigmaConfig): EnigmaChallenge {
+        val level = max(1, config.level)
+        val symbolCount = (2 + (level - 1) / 2).coerceAtMost(MAX_SYMBOLS)
+        val symbols = SYMBOL_POOL.take(symbolCount)
+        val random = Random(level + symbolCount)
+
+        val valueRangeMin = config.minValue
+        val valueRangeMax = max(config.maxValue, config.maxValue + level * 3)
+        val values = mutableMapOf<String, Int>()
+        val equations = mutableListOf<EnigmaEquation>()
+
+        val first = symbols[0]
+        val second = symbols[1]
+        val firstValue = random.nextInt(valueRangeMin + 1, valueRangeMax + 1)
+        val secondValue = random.nextInt(valueRangeMin, firstValue)
+
+        values[first] = firstValue
+        values[second] = secondValue
+
+        equations += EnigmaEquation("$first + $second", firstValue + secondValue)
+        equations += EnigmaEquation("$first - $second", firstValue - secondValue)
+
+        val availableOperators = buildOperatorsForLevel(level)
+
+        symbols.drop(2).forEach { symbol ->
+            val symbolValue = random.nextInt(valueRangeMin, valueRangeMax + 1)
+            values[symbol] = symbolValue
+            val knownSymbol = values.keys.random(random)
+            val knownValue = values.getValue(knownSymbol)
+            equations += buildEquation(
+                newSymbol = symbol,
+                newValue = symbolValue,
+                knownSymbol = knownSymbol,
+                knownValue = knownValue,
+                operators = availableOperators,
+                random = random
+            )
+        }
+
+        val expressionSymbols = symbols.shuffled(random).take(expressionSymbolCount(level, symbolCount))
+        val finalExpression = buildFinalExpression(expressionSymbols, values, availableOperators, random)
+
+        return EnigmaChallenge(
+            equations = equations,
+            finalExpression = finalExpression.expression,
+            answer = finalExpression.answer,
+            level = level
+        )
+    }
+
+    private fun buildEquation(
+        newSymbol: String,
+        newValue: Int,
+        knownSymbol: String,
+        knownValue: Int,
+        operators: List<Operator>,
+        random: Random
+    ): EnigmaEquation {
+        val shuffledOps = operators.shuffled(random)
+        for (op in shuffledOps) {
+            when (op) {
+                Operator.PLUS -> return EnigmaEquation("$newSymbol + $knownSymbol", newValue + knownValue)
+                Operator.MINUS -> {
+                    return if (newValue >= knownValue) {
+                        EnigmaEquation("$newSymbol - $knownSymbol", newValue - knownValue)
+                    } else {
+                        EnigmaEquation("$knownSymbol - $newSymbol", knownValue - newValue)
+                    }
+                }
+                Operator.MULTIPLY -> return EnigmaEquation("$newSymbol ${op.symbol} $knownSymbol", newValue * knownValue)
+                Operator.DIVIDE -> {
+                    if (knownValue != 0 && newValue % knownValue == 0) {
+                        return EnigmaEquation("$newSymbol ${op.symbol} $knownSymbol", newValue / knownValue)
+                    }
+                    if (newValue != 0 && knownValue % newValue == 0) {
+                        return EnigmaEquation("$knownSymbol ${op.symbol} $newSymbol", knownValue / newValue)
+                    }
+                }
+            }
+        }
+
+        return EnigmaEquation("$newSymbol + $knownSymbol", newValue + knownValue)
+    }
+
+    private fun buildFinalExpression(
+        symbols: List<String>,
+        values: Map<String, Int>,
+        operators: List<Operator>,
+        random: Random
+    ): FinalExpressionResult {
+        val multiTerm = symbols.size > 2
+        val expressionOperators = if (multiTerm) {
+            listOf(Operator.PLUS, Operator.MINUS)
+        } else {
+            operators
+        }
+
+        var expression = symbols.first()
+        var result = values.getValue(symbols.first())
+
+        symbols.drop(1).forEach { symbol ->
+            val value = values.getValue(symbol)
+            val operator = expressionOperators.random(random)
+            val resolvedOperator = resolveSafeOperator(operator, result, value)
+            expression += " ${resolvedOperator.symbol} $symbol"
+            result = resolvedOperator.apply(result, value)
+        }
+
+        return FinalExpressionResult(expression = "$expression = ?", answer = result)
+    }
+
+    private fun resolveSafeOperator(operator: Operator, current: Int, next: Int): Operator {
+        return when (operator) {
+            Operator.MINUS -> if (current - next < 0) Operator.PLUS else operator
+            Operator.DIVIDE -> if (next != 0 && current % next == 0) operator else Operator.PLUS
+            else -> operator
+        }
+    }
+
+    private fun buildOperatorsForLevel(level: Int): List<Operator> {
+        return when {
+            level < 3 -> listOf(Operator.PLUS, Operator.MINUS)
+            level < 5 -> listOf(Operator.PLUS, Operator.MINUS, Operator.MULTIPLY)
+            else -> listOf(Operator.PLUS, Operator.MINUS, Operator.MULTIPLY, Operator.DIVIDE)
+        }
+    }
+
+    private fun expressionSymbolCount(level: Int, symbolCount: Int): Int {
+        val desired = when {
+            level < 3 -> 2
+            level < 5 -> 3
+            else -> 4
+        }
+        return desired.coerceAtMost(symbolCount)
+    }
+
+    private data class FinalExpressionResult(
+        val expression: String,
+        val answer: Int
+    )
+
+    private enum class Operator(val symbol: String, val apply: (Int, Int) -> Int) {
+        PLUS("+", { a, b -> a + b }),
+        MINUS("-", { a, b -> a - b }),
+        MULTIPLY("x", { a, b -> a * b }),
+        DIVIDE("/", { a, b -> a / b })
+    }
+
+    private companion object {
+        private const val MAX_SYMBOLS = 8
+        private val SYMBOL_POOL = listOf("△", "⬡", "□", "▭", "○", "◇", "★", "A")
+    }
+}

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/domain/use_cases/GenerateEnigmaChallengeUseCase.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/domain/use_cases/GenerateEnigmaChallengeUseCase.kt
@@ -29,7 +29,7 @@ class GenerateEnigmaChallengeUseCase @Inject constructor() {
         values[second] = secondValue
 
         equations += EnigmaEquation("$first + $second", firstValue + secondValue)
-        equations += EnigmaEquation("$first - $second", firstValue - secondValue)
+        equations += EnigmaEquation("$first – $second", firstValue - secondValue)
 
         val availableOperators = buildOperatorsForLevel(level)
 
@@ -152,9 +152,9 @@ class GenerateEnigmaChallengeUseCase @Inject constructor() {
 
     private enum class Operator(val symbol: String, val apply: (Int, Int) -> Int) {
         PLUS("+", { a, b -> a + b }),
-        MINUS("-", { a, b -> a - b }),
-        MULTIPLY("x", { a, b -> a * b }),
-        DIVIDE("/", { a, b -> a / b })
+        MINUS("–", { a, b -> a - b }),
+        MULTIPLY("×", { a, b -> a * b }),
+        DIVIDE(":", { a, b -> a / b })
     }
 
     private companion object {

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/domain/use_cases/UpdateEnigmaScoreUseCase.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/domain/use_cases/UpdateEnigmaScoreUseCase.kt
@@ -1,0 +1,21 @@
+package eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.domain.use_cases
+
+import eu.indiewalkabout.mathbrainer.feat_statistics.domain.model.GameScores.Companion.emptyScores
+import eu.indiewalkabout.mathbrainer.feat_statistics.domain.repository.MathBrainerRepository
+import javax.inject.Inject
+import kotlin.math.max
+import kotlinx.coroutines.flow.firstOrNull
+
+class UpdateEnigmaScoreUseCase @Inject constructor(
+    private val repository: MathBrainerRepository
+) {
+    suspend operator fun invoke(sessionScore: Int) {
+        val currentScores = repository.observeGameScores().firstOrNull() ?: emptyScores
+        val updatedScores = currentScores.copy(
+            enigma_game_score = max(currentScores.enigma_game_score, sessionScore),
+            id = 0,
+            global_score = currentScores.global_score + sessionScore
+        )
+        repository.insertGameScores(updatedScores)
+    }
+}

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/components/EnigmaChallengeCard.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/components/EnigmaChallengeCard.kt
@@ -4,13 +4,19 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.domain.model.EnigmaChallenge
@@ -18,6 +24,7 @@ import eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.domain.model.EnigmaC
 @Composable
 fun EnigmaChallengeCard(
     challenge: EnigmaChallenge,
+    inputValue: String,
     modifier: Modifier = Modifier
 ) {
     Card(
@@ -45,6 +52,38 @@ fun EnigmaChallengeCard(
                 color = MaterialTheme.colorScheme.primary,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.fillMaxWidth()
+            )
+            
+            // Input display
+            TextField(
+                value = inputValue,
+                onValueChange = {},
+                readOnly = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp),
+                textStyle = MaterialTheme.typography.headlineMedium.copy(
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.colorScheme.onBackground
+                ),
+                colors = TextFieldDefaults.colors(
+                    focusedContainerColor = MaterialTheme.colorScheme.background,
+                    unfocusedContainerColor = MaterialTheme.colorScheme.background,
+                    disabledContainerColor = MaterialTheme.colorScheme.background,
+                    focusedIndicatorColor = Color.Transparent,
+                    unfocusedIndicatorColor = Color.Transparent,
+                    cursorColor = Color.Transparent
+                ),
+                visualTransformation = VisualTransformation.None,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.None),
+                placeholder = {
+                    Text(
+                        text = "",
+                        style = MaterialTheme.typography.headlineMedium,
+                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
+                        textAlign = TextAlign.Center
+                    )
+                }
             )
         }
     }

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/components/EnigmaChallengeCard.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/components/EnigmaChallengeCard.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -32,8 +33,10 @@ fun EnigmaChallengeCard(
                     text = "${equation.leftExpression} = ${equation.result}",
                     style = MaterialTheme.typography.headlineSmall,
                     color = MaterialTheme.colorScheme.onSurface,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.fillMaxWidth()
+                    textAlign = TextAlign.Start,
+                    modifier = Modifier
+                        .fillMaxWidth(0.9f)
+                        .align(Alignment.CenterHorizontally)
                 )
             }
             Text(

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/components/EnigmaChallengeCard.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/components/EnigmaChallengeCard.kt
@@ -1,0 +1,48 @@
+package eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.presentation.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.domain.model.EnigmaChallenge
+
+@Composable
+fun EnigmaChallengeCard(
+    challenge: EnigmaChallenge,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            challenge.equations.forEach { equation ->
+                Text(
+                    text = "${equation.leftExpression} = ${equation.result}",
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+            Text(
+                text = challenge.finalExpression,
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.primary,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/components/EnigmaHeader.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/components/EnigmaHeader.kt
@@ -1,0 +1,88 @@
+package eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.presentation.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import eu.indiewalkabout.mathbrainer.R
+import eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.presentation.state.EnigmaUiState
+import eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_write.presentation.components.LevelProgressBar
+
+@Composable
+fun EnigmaHeader(state: EnigmaUiState) {
+    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = stringResource(id = R.string.level_with_value, state.level),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+
+                LevelProgressBar(
+                    currentProgress = state.challengesCompleted,
+                    totalSegments = state.challengesPerLevel,
+                    segmentColor = MaterialTheme.colorScheme.primary,
+                    backgroundColor = MaterialTheme.colorScheme.secondaryContainer,
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(horizontal = 16.dp)
+                        .height(8.dp)
+                )
+
+                Text(
+                    text = stringResource(id = R.string.lives_with_value, state.lives),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = stringResource(id = R.string.score_with_value, state.score),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.Bold
+                )
+                state.highScore?.let { highScore ->
+                    Text(
+                        text = stringResource(id = R.string.highscore_with_value, highScore),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            LinearProgressIndicator(
+                progress = state.timerProgress,
+                modifier = Modifier.fillMaxWidth(),
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
+    }
+}

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/components/EnigmaHeader.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/components/EnigmaHeader.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -20,7 +19,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import eu.indiewalkabout.mathbrainer.R
 import eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.presentation.state.EnigmaUiState
-import eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_write.presentation.components.LevelProgressBar
 
 @Composable
 fun EnigmaHeader(state: EnigmaUiState) {
@@ -37,7 +35,7 @@ fun EnigmaHeader(state: EnigmaUiState) {
                     color = MaterialTheme.colorScheme.onSurface
                 )
 
-                LevelProgressBar(
+                /*LevelProgressBar(
                     currentProgress = state.challengesCompleted,
                     totalSegments = state.challengesPerLevel,
                     segmentColor = MaterialTheme.colorScheme.primary,
@@ -46,7 +44,7 @@ fun EnigmaHeader(state: EnigmaUiState) {
                         .weight(1f)
                         .padding(horizontal = 16.dp)
                         .height(8.dp)
-                )
+                )*/
 
                 Text(
                     text = stringResource(id = R.string.lives_with_value, state.lives),

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/components/EnigmaHeader.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/components/EnigmaHeader.kt
@@ -76,13 +76,6 @@ fun EnigmaHeader(state: EnigmaUiState) {
                 }
             }
 
-            Spacer(modifier = Modifier.height(12.dp))
-
-            LinearProgressIndicator(
-                progress = state.timerProgress,
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.primary
-            )
         }
     }
 }

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/components/EnigmaHeader.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/components/EnigmaHeader.kt
@@ -35,17 +35,6 @@ fun EnigmaHeader(state: EnigmaUiState) {
                     color = MaterialTheme.colorScheme.onSurface
                 )
 
-                /*LevelProgressBar(
-                    currentProgress = state.challengesCompleted,
-                    totalSegments = state.challengesPerLevel,
-                    segmentColor = MaterialTheme.colorScheme.primary,
-                    backgroundColor = MaterialTheme.colorScheme.secondaryContainer,
-                    modifier = Modifier
-                        .weight(1f)
-                        .padding(horizontal = 16.dp)
-                        .height(8.dp)
-                )*/
-
                 Text(
                     text = stringResource(id = R.string.lives_with_value, state.lives),
                     style = MaterialTheme.typography.bodyLarge,

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/state/EnigmaUiState.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/state/EnigmaUiState.kt
@@ -11,17 +11,8 @@ data class EnigmaUiState(
     val challengesCompleted: Int = 0,
     val challengesPerLevel: Int = 3,
     val lives: Int = 3,
-    val timeRemaining: Long = INITIAL_TIMER_LENGTH,
-    val totalTime: Long = INITIAL_TIMER_LENGTH,
     val feedback: Feedback? = null,
     val isGameOver: Boolean = false
 ) {
-    val timerProgress: Float
-        get() = if (totalTime == 0L) 0f else (timeRemaining.toFloat() / totalTime.toFloat()).coerceIn(0f, 1f)
-
     enum class Feedback { SUCCESS, FAILURE }
-
-    companion object {
-        const val INITIAL_TIMER_LENGTH: Long = 25_000L
-    }
 }

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/state/EnigmaUiState.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/state/EnigmaUiState.kt
@@ -1,0 +1,27 @@
+package eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.presentation.state
+
+import eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.domain.model.EnigmaChallenge
+
+data class EnigmaUiState(
+    val challenge: EnigmaChallenge? = null,
+    val inputValue: String = "",
+    val score: Int = 0,
+    val highScore: Int? = null,
+    val level: Int = 1,
+    val challengesCompleted: Int = 0,
+    val challengesPerLevel: Int = 3,
+    val lives: Int = 3,
+    val timeRemaining: Long = INITIAL_TIMER_LENGTH,
+    val totalTime: Long = INITIAL_TIMER_LENGTH,
+    val feedback: Feedback? = null,
+    val isGameOver: Boolean = false
+) {
+    val timerProgress: Float
+        get() = if (totalTime == 0L) 0f else (timeRemaining.toFloat() / totalTime.toFloat()).coerceIn(0f, 1f)
+
+    enum class Feedback { SUCCESS, FAILURE }
+
+    companion object {
+        const val INITIAL_TIMER_LENGTH: Long = 25_000L
+    }
+}

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/ui/EnigmaGameScreen.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/ui/EnigmaGameScreen.kt
@@ -1,0 +1,124 @@
+package eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.presentation.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import eu.indiewalkabout.mathbrainer.R
+import eu.indiewalkabout.mathbrainer.core.presentation.components.GameOverDialog
+import eu.indiewalkabout.mathbrainer.core.presentation.components.ResultBanner
+import eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.presentation.components.EnigmaChallengeCard
+import eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.presentation.components.EnigmaHeader
+import eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.presentation.state.EnigmaUiState
+import eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_write.presentation.components.keyboard.Keypad
+
+@Composable
+fun EnigmaGameScreen(
+    initialHighScore: Int = 0,
+    onBack: () -> Unit,
+    viewModel: EnigmaViewModel = hiltViewModel()
+) {
+    val state by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(initialHighScore) {
+        viewModel.startGame(initialHighScore)
+    }
+
+    Scaffold(
+        topBar = {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(MaterialTheme.colorScheme.primary)
+                    .padding(horizontal = 12.dp, vertical = 16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = {
+                    viewModel.onQuitGame()
+                    onBack()
+                }) {
+                    Icon(
+                        imageVector = Icons.Default.ArrowBack,
+                        contentDescription = stringResource(id = R.string.navigate_back),
+                        tint = MaterialTheme.colorScheme.onPrimary
+                    )
+                }
+                Spacer(modifier = Modifier.padding(4.dp))
+                Column {
+                    Text(
+                        text = stringResource(id = R.string.enigma_title),
+                        style = MaterialTheme.typography.titleLarge,
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                    Text(
+                        text = stringResource(id = R.string.enigma_subtitle),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                }
+            }
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            EnigmaHeader(state)
+            state.challenge?.let { challenge ->
+                EnigmaChallengeCard(challenge = challenge)
+            }
+
+            when (state.feedback) {
+                EnigmaUiState.Feedback.SUCCESS -> ResultBanner(
+                    text = stringResource(id = R.string.ok_str),
+                    color = MaterialTheme.colorScheme.primary
+                )
+                EnigmaUiState.Feedback.FAILURE -> ResultBanner(
+                    text = stringResource(id = R.string.wrong_answer),
+                    color = MaterialTheme.colorScheme.error
+                )
+                null -> ResultBanner(
+                    text = stringResource(id = R.string.enigma_prompt),
+                    color = MaterialTheme.colorScheme.onBackground
+                )
+            }
+
+            Keypad(
+                inputValue = state.inputValue,
+                onDigitPressed = { digit -> viewModel.onDigitPressed(digit) },
+                onDelete = { viewModel.onDelete() },
+                onSubmit = { viewModel.submitAnswer() }
+            )
+        }
+    }
+
+    if (state.isGameOver) {
+        GameOverDialog(onDismiss = {
+            viewModel.onQuitGame()
+            onBack()
+        })
+    }
+}

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/ui/EnigmaGameScreen.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/ui/EnigmaGameScreen.kt
@@ -88,7 +88,10 @@ fun EnigmaGameScreen(
         ) {
             EnigmaHeader(state)
             state.challenge?.let { challenge ->
-                EnigmaChallengeCard(challenge = challenge)
+                EnigmaChallengeCard(
+                    challenge = challenge,
+                    inputValue = state.inputValue
+                )
             }
 
             when (state.feedback) {

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/ui/EnigmaViewModel.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/ui/EnigmaViewModel.kt
@@ -7,7 +7,6 @@ import eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.domain.model.EnigmaC
 import eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.domain.use_cases.GenerateEnigmaChallengeUseCase
 import eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.domain.use_cases.UpdateEnigmaScoreUseCase
 import eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.presentation.state.EnigmaUiState
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -22,8 +21,6 @@ class EnigmaViewModel @Inject constructor(
     private val updateEnigmaScoreUseCase: UpdateEnigmaScoreUseCase
 ) : ViewModel() {
 
-    private var timerJob: Job? = null
-    private var timerLength = EnigmaUiState.INITIAL_TIMER_LENGTH
     private var challengesPerLevel = INITIAL_CHALLENGES_PER_LEVEL
     private var challengesCompleted = 0
     private var isScorePersisted = false
@@ -34,7 +31,7 @@ class EnigmaViewModel @Inject constructor(
     fun startGame(initialHighScore: Int = 0) {
         isScorePersisted = false
         _uiState.update { it.copy(highScore = initialHighScore.takeIf { score -> score > 0 }) }
-        launchNewChallenge(resetTimer = true)
+        launchNewChallenge()
     }
 
     fun onDigitPressed(digit: Int) {
@@ -53,7 +50,6 @@ class EnigmaViewModel @Inject constructor(
     fun submitAnswer() {
         val challenge = _uiState.value.challenge ?: return
         val attempt = _uiState.value.inputValue.toIntOrNull() ?: return
-        timerJob?.cancel()
 
         if (attempt == challenge.answer) {
             handleSuccess()
@@ -66,7 +62,7 @@ class EnigmaViewModel @Inject constructor(
         persistScoreIfNeeded()
     }
 
-    private fun launchNewChallenge(resetTimer: Boolean) {
+    private fun launchNewChallenge() {
         val level = _uiState.value.level
         val challenge = generateEnigmaChallengeUseCase(
             EnigmaConfig(
@@ -81,30 +77,12 @@ class EnigmaViewModel @Inject constructor(
                 challenge = challenge,
                 inputValue = "",
                 feedback = null,
-                timeRemaining = timerLength,
-                totalTime = timerLength,
                 challengesPerLevel = challengesPerLevel,
                 challengesCompleted = challengesCompleted
             )
         }
-
-        if (resetTimer) {
-            startTimer()
-        }
     }
 
-    private fun startTimer() {
-        timerJob?.cancel()
-        timerJob = viewModelScope.launch {
-            var remaining = timerLength
-            while (remaining > 0) {
-                delay(COUNTDOWN_STEP)
-                remaining -= COUNTDOWN_STEP
-                _uiState.update { it.copy(timeRemaining = remaining) }
-            }
-            handleCountdownExpired()
-        }
-    }
 
     private fun handleSuccess() {
         challengesCompleted++
@@ -137,21 +115,12 @@ class EnigmaViewModel @Inject constructor(
         }
     }
 
-    private fun handleCountdownExpired() {
-        val remainingLives = _uiState.value.lives - 1
-        _uiState.update { it.copy(lives = remainingLives, feedback = EnigmaUiState.Feedback.FAILURE, timeRemaining = 0L) }
-        if (remainingLives <= 0) {
-            onGameOver()
-        } else {
-            startDelayedChallenge()
-        }
-    }
 
     private fun startDelayedChallenge() {
         viewModelScope.launch {
             delay(NEXT_CHALLENGE_DELAY)
             if (!_uiState.value.isGameOver) {
-                launchNewChallenge(resetTimer = true)
+                launchNewChallenge()
             }
         }
     }
@@ -159,12 +128,10 @@ class EnigmaViewModel @Inject constructor(
     private fun promoteLevel() {
         challengesCompleted = 0
         challengesPerLevel += 1
-        timerLength += TIMER_INCREMENT
         _uiState.update { it.copy(level = it.level + 1) }
     }
 
     private fun onGameOver() {
-        timerJob?.cancel()
         _uiState.update { it.copy(isGameOver = true) }
         persistScoreIfNeeded()
     }
@@ -182,9 +149,7 @@ class EnigmaViewModel @Inject constructor(
 
     companion object {
         private const val SCORE_INCREMENT = 50
-        private const val COUNTDOWN_STEP = 1_000L
         private const val NEXT_CHALLENGE_DELAY = 1_200L
-        private const val TIMER_INCREMENT = 2_000L
         private const val INITIAL_CHALLENGES_PER_LEVEL = 3
         private const val MIN_VALUE = 2
         private const val MAX_VALUE_BASE = 18

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/ui/EnigmaViewModel.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/ui/EnigmaViewModel.kt
@@ -21,8 +21,6 @@ class EnigmaViewModel @Inject constructor(
     private val updateEnigmaScoreUseCase: UpdateEnigmaScoreUseCase
 ) : ViewModel() {
 
-    // private var challengesPerLevel = INITIAL_CHALLENGES_PER_LEVEL
-    // private var challengesCompleted = 0
     private var isScorePersisted = false
 
     private val _uiState = MutableStateFlow(EnigmaUiState())
@@ -77,29 +75,20 @@ class EnigmaViewModel @Inject constructor(
                 challenge = challenge,
                 inputValue = "",
                 feedback = null,
-                // challengesPerLevel = challengesPerLevel,
-                // challengesCompleted = challengesCompleted
             )
         }
     }
 
 
     private fun handleSuccess() {
-        // challengesCompleted++
         promoteLevel()
         val newScore = _uiState.value.score + SCORE_INCREMENT
-
-        /*if (challengesCompleted >= challengesPerLevel) {
-            promoteLevel()
-        }*/
 
         _uiState.update {
             it.copy(
                 feedback = EnigmaUiState.Feedback.SUCCESS,
                 score = newScore,
                 highScore = maxOf(it.highScore ?: 0, newScore),
-                // challengesCompleted = challengesCompleted,
-                // challengesPerLevel = challengesPerLevel
             )
         }
         startDelayedChallenge()
@@ -127,8 +116,6 @@ class EnigmaViewModel @Inject constructor(
     }
 
     private fun promoteLevel() {
-        // challengesCompleted = 0
-        // challengesPerLevel += 1
         _uiState.update { it.copy(level = it.level + 1) }
     }
 
@@ -151,7 +138,6 @@ class EnigmaViewModel @Inject constructor(
     companion object {
         private const val SCORE_INCREMENT = 50
         private const val NEXT_CHALLENGE_DELAY = 1_200L
-        private const val INITIAL_CHALLENGES_PER_LEVEL = 3
         private const val MIN_VALUE = 2
         private const val MAX_VALUE_BASE = 18
         private const val LEVEL_VALUE_INCREMENT = 4

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/ui/EnigmaViewModel.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/ui/EnigmaViewModel.kt
@@ -1,0 +1,193 @@
+package eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.presentation.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.domain.model.EnigmaConfig
+import eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.domain.use_cases.GenerateEnigmaChallengeUseCase
+import eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.domain.use_cases.UpdateEnigmaScoreUseCase
+import eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.presentation.state.EnigmaUiState
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class EnigmaViewModel @Inject constructor(
+    private val generateEnigmaChallengeUseCase: GenerateEnigmaChallengeUseCase,
+    private val updateEnigmaScoreUseCase: UpdateEnigmaScoreUseCase
+) : ViewModel() {
+
+    private var timerJob: Job? = null
+    private var timerLength = EnigmaUiState.INITIAL_TIMER_LENGTH
+    private var challengesPerLevel = INITIAL_CHALLENGES_PER_LEVEL
+    private var challengesCompleted = 0
+    private var isScorePersisted = false
+
+    private val _uiState = MutableStateFlow(EnigmaUiState())
+    val uiState: StateFlow<EnigmaUiState> = _uiState.asStateFlow()
+
+    fun startGame(initialHighScore: Int = 0) {
+        isScorePersisted = false
+        _uiState.update { it.copy(highScore = initialHighScore.takeIf { score -> score > 0 }) }
+        launchNewChallenge(resetTimer = true)
+    }
+
+    fun onDigitPressed(digit: Int) {
+        if (_uiState.value.isGameOver) return
+        _uiState.update { it.copy(inputValue = (it.inputValue + digit.toString()).take(7)) }
+    }
+
+    fun onDelete() {
+        if (_uiState.value.isGameOver) return
+        _uiState.update { current ->
+            val newValue = if (current.inputValue.isNotEmpty()) current.inputValue.dropLast(1) else ""
+            current.copy(inputValue = newValue)
+        }
+    }
+
+    fun submitAnswer() {
+        val challenge = _uiState.value.challenge ?: return
+        val attempt = _uiState.value.inputValue.toIntOrNull() ?: return
+        timerJob?.cancel()
+
+        if (attempt == challenge.answer) {
+            handleSuccess()
+        } else {
+            handleFailure()
+        }
+    }
+
+    fun onQuitGame() {
+        persistScoreIfNeeded()
+    }
+
+    private fun launchNewChallenge(resetTimer: Boolean) {
+        val level = _uiState.value.level
+        val challenge = generateEnigmaChallengeUseCase(
+            EnigmaConfig(
+                level = level,
+                minValue = MIN_VALUE,
+                maxValue = MAX_VALUE_BASE + level * LEVEL_VALUE_INCREMENT
+            )
+        )
+
+        _uiState.update {
+            it.copy(
+                challenge = challenge,
+                inputValue = "",
+                feedback = null,
+                timeRemaining = timerLength,
+                totalTime = timerLength,
+                challengesPerLevel = challengesPerLevel,
+                challengesCompleted = challengesCompleted
+            )
+        }
+
+        if (resetTimer) {
+            startTimer()
+        }
+    }
+
+    private fun startTimer() {
+        timerJob?.cancel()
+        timerJob = viewModelScope.launch {
+            var remaining = timerLength
+            while (remaining > 0) {
+                delay(COUNTDOWN_STEP)
+                remaining -= COUNTDOWN_STEP
+                _uiState.update { it.copy(timeRemaining = remaining) }
+            }
+            handleCountdownExpired()
+        }
+    }
+
+    private fun handleSuccess() {
+        challengesCompleted++
+        val newScore = _uiState.value.score + SCORE_INCREMENT
+
+        if (challengesCompleted >= challengesPerLevel) {
+            promoteLevel()
+        }
+
+        _uiState.update {
+            it.copy(
+                feedback = EnigmaUiState.Feedback.SUCCESS,
+                score = newScore,
+                highScore = maxOf(it.highScore ?: 0, newScore),
+                challengesCompleted = challengesCompleted,
+                challengesPerLevel = challengesPerLevel
+            )
+        }
+        startDelayedChallenge()
+    }
+
+    private fun handleFailure() {
+        val remainingLives = _uiState.value.lives - 1
+        _uiState.update { it.copy(lives = remainingLives, feedback = EnigmaUiState.Feedback.FAILURE) }
+
+        if (remainingLives <= 0) {
+            onGameOver()
+        } else {
+            startDelayedChallenge()
+        }
+    }
+
+    private fun handleCountdownExpired() {
+        val remainingLives = _uiState.value.lives - 1
+        _uiState.update { it.copy(lives = remainingLives, feedback = EnigmaUiState.Feedback.FAILURE, timeRemaining = 0L) }
+        if (remainingLives <= 0) {
+            onGameOver()
+        } else {
+            startDelayedChallenge()
+        }
+    }
+
+    private fun startDelayedChallenge() {
+        viewModelScope.launch {
+            delay(NEXT_CHALLENGE_DELAY)
+            if (!_uiState.value.isGameOver) {
+                launchNewChallenge(resetTimer = true)
+            }
+        }
+    }
+
+    private fun promoteLevel() {
+        challengesCompleted = 0
+        challengesPerLevel += 1
+        timerLength += TIMER_INCREMENT
+        _uiState.update { it.copy(level = it.level + 1) }
+    }
+
+    private fun onGameOver() {
+        timerJob?.cancel()
+        _uiState.update { it.copy(isGameOver = true) }
+        persistScoreIfNeeded()
+    }
+
+    private fun persistScoreIfNeeded() {
+        if (isScorePersisted) return
+        isScorePersisted = true
+        val finalScore = _uiState.value.score
+        viewModelScope.launch {
+            if (finalScore > 0) {
+                updateEnigmaScoreUseCase(finalScore)
+            }
+        }
+    }
+
+    companion object {
+        private const val SCORE_INCREMENT = 50
+        private const val COUNTDOWN_STEP = 1_000L
+        private const val NEXT_CHALLENGE_DELAY = 1_200L
+        private const val TIMER_INCREMENT = 2_000L
+        private const val INITIAL_CHALLENGES_PER_LEVEL = 3
+        private const val MIN_VALUE = 2
+        private const val MAX_VALUE_BASE = 18
+        private const val LEVEL_VALUE_INCREMENT = 4
+    }
+}

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/ui/EnigmaViewModel.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/ui/EnigmaViewModel.kt
@@ -21,8 +21,8 @@ class EnigmaViewModel @Inject constructor(
     private val updateEnigmaScoreUseCase: UpdateEnigmaScoreUseCase
 ) : ViewModel() {
 
-    private var challengesPerLevel = INITIAL_CHALLENGES_PER_LEVEL
-    private var challengesCompleted = 0
+    // private var challengesPerLevel = INITIAL_CHALLENGES_PER_LEVEL
+    // private var challengesCompleted = 0
     private var isScorePersisted = false
 
     private val _uiState = MutableStateFlow(EnigmaUiState())
@@ -77,28 +77,29 @@ class EnigmaViewModel @Inject constructor(
                 challenge = challenge,
                 inputValue = "",
                 feedback = null,
-                challengesPerLevel = challengesPerLevel,
-                challengesCompleted = challengesCompleted
+                // challengesPerLevel = challengesPerLevel,
+                // challengesCompleted = challengesCompleted
             )
         }
     }
 
 
     private fun handleSuccess() {
-        challengesCompleted++
+        // challengesCompleted++
+        promoteLevel()
         val newScore = _uiState.value.score + SCORE_INCREMENT
 
-        if (challengesCompleted >= challengesPerLevel) {
+        /*if (challengesCompleted >= challengesPerLevel) {
             promoteLevel()
-        }
+        }*/
 
         _uiState.update {
             it.copy(
                 feedback = EnigmaUiState.Feedback.SUCCESS,
                 score = newScore,
                 highScore = maxOf(it.highScore ?: 0, newScore),
-                challengesCompleted = challengesCompleted,
-                challengesPerLevel = challengesPerLevel
+                // challengesCompleted = challengesCompleted,
+                // challengesPerLevel = challengesPerLevel
             )
         }
         startDelayedChallenge()
@@ -126,8 +127,8 @@ class EnigmaViewModel @Inject constructor(
     }
 
     private fun promoteLevel() {
-        challengesCompleted = 0
-        challengesPerLevel += 1
+        // challengesCompleted = 0
+        // challengesPerLevel += 1
         _uiState.update { it.copy(level = it.level + 1) }
     }
 

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_home/data/local/GamesStaticData.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_home/data/local/GamesStaticData.kt
@@ -68,6 +68,10 @@ val gamesDefinitionsList = listOf(
         titleRes = R.string.game_card_sequence_complete_text,
     ),
     GameDefinition(
+        id = "enigma",
+        titleRes = R.string.game_card_enigma_text,
+    ),
+    GameDefinition(
         id = "double",
         titleRes = R.string.game_card_double_number_title , // R.string.double_number_title,
         // descriptionRes = R.string.double_number_description,

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_home/domain/model/GameTypes.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_home/domain/model/GameTypes.kt
@@ -70,6 +70,10 @@ enum class GameTypes(
     SEQUENCE_COMPLETE(
         id = "sequence_complete",
         scoreField = { it.sequence_complete_game_score }
+    ),
+    ENIGMA(
+        id = "enigma",
+        scoreField = { it.enigma_game_score }
     );
 
     companion object {

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_home/domain/use_cases/GetGameScoresUseCase.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_home/domain/use_cases/GetGameScoresUseCase.kt
@@ -11,10 +11,10 @@ import javax.inject.Inject
 class GetGameScoresUseCase @Inject constructor(
     private val repository: MathBrainerRepository
 ) {
-    private val emptyScores = GameScores(
-        global_score = 0,
-        doublenumber_game_score = 0,
-        sum_choose_result_game_score = 0,
+        private val emptyScores = GameScores(
+            global_score = 0,
+            doublenumber_game_score = 0,
+            sum_choose_result_game_score = 0,
         diff_choose_result_game_score = 0,
         mult_choose_result_game_score = 0,
         div_choose_result_game_score = 0,
@@ -24,11 +24,12 @@ class GetGameScoresUseCase @Inject constructor(
         mult_write_result_game_score = 0,
         div_write_result_game_score = 0,
         mix_write_result_game_score = 0,
-        random_op_game_score = 0,
-        count_objects_game_score = 0,
-        number_order_game_score = 0,
-        sequence_complete_game_score = 0
-    )
+            random_op_game_score = 0,
+            count_objects_game_score = 0,
+            number_order_game_score = 0,
+            sequence_complete_game_score = 0,
+            enigma_game_score = 0
+        )
 
     suspend operator fun invoke(): Flow<GameScores> {
         Log.d("GetGameScoresUseCase", "Starting to observe game scores")

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_home/presentation/ui/HomeScreen.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_home/presentation/ui/HomeScreen.kt
@@ -194,6 +194,13 @@ fun HomeScreen(
                                         )
                                     )
                                 }
+                                GameTypes.ENIGMA -> {
+                                    navController.navigate(
+                                        ScreenRoutes.EnigmaGame.createRoute(
+                                            highScore = game.highScore ?: 0
+                                        )
+                                    )
+                                }
 
                                 null -> navController.navigate(ScreenRoutes.Home.route)
                             }
@@ -205,5 +212,4 @@ fun HomeScreen(
         }
     }
 }
-
 

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_statistics/data/local/db/MathBrainerDatabase.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_statistics/data/local/db/MathBrainerDatabase.kt
@@ -15,7 +15,7 @@ import eu.indiewalkabout.mathbrainer.feat_statistics.domain.model.GameStatistics
         GameStatistics::class,
         MathWriteGameStats::class
     ],
-    version = 4,
+    version = 5,
     exportSchema = true
 )
 @TypeConverters(DateConverter::class)

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_statistics/data/local/db/MathBrainerDatabase.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_statistics/data/local/db/MathBrainerDatabase.kt
@@ -15,7 +15,7 @@ import eu.indiewalkabout.mathbrainer.feat_statistics.domain.model.GameStatistics
         GameStatistics::class,
         MathWriteGameStats::class
     ],
-    version = 5,
+    version = 6,
     exportSchema = true
 )
 @TypeConverters(DateConverter::class)

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_statistics/domain/model/GameScores.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_statistics/domain/model/GameScores.kt
@@ -22,7 +22,8 @@ data class GameScores(
     val random_op_game_score: Int,
     val count_objects_game_score: Int,
     val number_order_game_score: Int,
-    val sequence_complete_game_score: Int
+    val sequence_complete_game_score: Int,
+    val enigma_game_score: Int
 ){
     companion object {
         val emptyScores = GameScores(
@@ -41,7 +42,8 @@ data class GameScores(
             random_op_game_score = 0,
             count_objects_game_score = 0,
             number_order_game_score = 0,
-            sequence_complete_game_score = 0
+            sequence_complete_game_score = 0,
+            enigma_game_score = 0
         )
     }
 }

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_statistics/presentation/ui/StatisticScreen.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_statistics/presentation/ui/StatisticScreen.kt
@@ -166,6 +166,13 @@ fun StatisticScreen(
                                         )
                                     )
                                 }
+                                GameTypes.ENIGMA -> {
+                                    navController.navigate(
+                                        ScreenRoutes.EnigmaGame.createRoute(
+                                            highScore = game.highScore ?: 0
+                                        )
+                                    )
+                                }
 
                                 null -> navController.navigate(ScreenRoutes.Home.route)
                             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,9 @@
     <string name="number_order_description">Order the numbers correctly.</string>
     <string name="sequence_complete_title">Sequence Solver</string>
     <string name="sequence_complete_description">Complete the sequence by finding the missing number.</string>
+    <string name="enigma_title">Enigma</string>
+    <string name="enigma_subtitle">Decode the symbols and solve the final equation.</string>
+    <string name="enigma_prompt">Find the hidden values and solve the last line.</string>
     <string name="random_operations_title">Random Operations</string>
     <string name="random_operations_description">Solve random math operations.</string>
     <string name="random_operations_subtitle">Choose the operation that makes the equation true.</string>
@@ -115,6 +118,7 @@
     <string name="game_card_write_result_div_text"  >   :    \n        </string>
     <string name="game_card_double_number_title"    >   2x   \n        </string>
     <string name="game_card_sequence_complete_text" >1  2  4  ?\n        </string>
+    <string name="game_card_enigma_text">△  □  ?\n        </string>
 
     <string name="sequence_rule_reveal">Rule: %1$s</string>
     <string name="sequence_correct_answer">Missing number: %1$d</string>


### PR DESCRIPTION
### Motivation
- Introduce a new puzzle-style game called `Enigma` where players deduce symbol/letter values from provided equations and solve a final expression to expand the app's game roster.
- Reuse existing game architecture and difficulty progression patterns so `Enigma` behaves consistently with other games (levels, timers, lives, scoring).
- Persist high scores and surface `Enigma` in Home and Statistics so players can access and track progress like other game modes.
- Keep symbol/operation generation safe and progressive so early levels are simpler and later levels add more symbols and operators.

### Description
- Added a new `feat_enigma` feature containing domain models (`EnigmaConfig`, `EnigmaEquation`, `EnigmaChallenge`), core generation logic (`GenerateEnigmaChallengeUseCase`), and score persistence (`UpdateEnigmaScoreUseCase`).
- Implemented UI and presentation pieces including `EnigmaGameScreen`, `EnigmaViewModel`, `EnigmaUiState`, `EnigmaHeader`, and `EnigmaChallengeCard`, and wired the keypad reuse from existing components via `Keypad`.
- Integrated `Enigma` into navigation by adding `ScreenRoutes.EnigmaGame`, updating `NavGraph` composable routing, and exposing the game in the home/statistics games list via `GameTypes.ENIGMA` and `GamesStaticData` entry.
- Extended persistence schema by adding `enigma_game_score` to `GameScores`, updating `emptyScores`, and bumping Room database `version` to `5`, plus added new string resources for `Enigma` labels and cards.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69480ab72364832a8ee098541d5f6900)