### PR TITLE
Enhance random operation puzzles with multi-step equations

### DIFF
--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_random_operation/domain/model/RandomOperationChallenge.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_random_operation/domain/model/RandomOperationChallenge.kt
@@ -1,8 +1,18 @@
 package eu.indiewalkabout.mathbrainer.feat_games.feat_math_random_operation.domain.model
 
+enum class ExpressionGrouping {
+    NONE,
+    LEFT,
+    RIGHT
+}
+
 data class RandomOperationChallenge(
-    val firstOperand: Int,
-    val secondOperand: Int,
+    val operands: List<Int>,
+    val operations: List<Char>,
+    val hiddenOperationIndex: Int,
     val result: Int,
+    val grouping: ExpressionGrouping = ExpressionGrouping.NONE
+) {
     val correctOperation: Char
-)
+        get() = operations[hiddenOperationIndex]
+}

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_random_operation/domain/model/RandomOperationConfig.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_random_operation/domain/model/RandomOperationConfig.kt
@@ -8,5 +8,6 @@ data class RandomOperationConfig(
     val multHighMax: Int,
     val divMin: Int,
     val divLowMax: Int,
-    val divHighMax: Int
+    val divHighMax: Int,
+    val level: Int
 )

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_random_operation/domain/use_cases/GenerateRandomOperationChallengeUseCase.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_random_operation/domain/use_cases/GenerateRandomOperationChallengeUseCase.kt
@@ -1,5 +1,6 @@
 package eu.indiewalkabout.mathbrainer.feat_games.feat_math_random_operation.domain.use_cases
 
+import eu.indiewalkabout.mathbrainer.feat_games.feat_math_random_operation.domain.model.ExpressionGrouping
 import eu.indiewalkabout.mathbrainer.feat_games.feat_math_random_operation.domain.model.RandomOperationChallenge
 import eu.indiewalkabout.mathbrainer.feat_games.feat_math_random_operation.domain.model.RandomOperationConfig
 import javax.inject.Inject
@@ -7,7 +8,69 @@ import kotlin.random.Random
 
 class GenerateRandomOperationChallengeUseCase @Inject constructor() {
     suspend operator fun invoke(config: RandomOperationConfig): RandomOperationChallenge {
+        val useMultiStep = shouldUseMultiStep(config.level)
+        return if (useMultiStep) {
+            buildMultiStep(config)
+        } else {
+            buildSimple(config)
+        }
+    }
+
+    private fun buildSimple(config: RandomOperationConfig): RandomOperationChallenge {
         val operation = OPERATIONS.random()
+        val operationResult = buildBinaryOperation(config, operation)
+        return RandomOperationChallenge(
+            operands = listOf(operationResult.leftOperand, operationResult.rightOperand),
+            operations = listOf(operation),
+            hiddenOperationIndex = 0,
+            result = operationResult.result,
+            grouping = ExpressionGrouping.NONE
+        )
+    }
+
+    private fun buildMultiStep(config: RandomOperationConfig): RandomOperationChallenge {
+        repeat(MAX_ATTEMPTS) {
+            val grouping = if (Random.nextBoolean()) ExpressionGrouping.LEFT else ExpressionGrouping.RIGHT
+            val op1 = OPERATIONS.random()
+            val op2 = OPERATIONS.random()
+            val hiddenIndex = if (config.level >= 4) Random.nextInt(0, 2) else 0
+            if (grouping == ExpressionGrouping.LEFT) {
+                val inner = buildBinaryOperation(config, op1)
+                val outer = buildOuterWithLeftOperand(inner.result, op2, config) ?: return@repeat
+                return RandomOperationChallenge(
+                    operands = listOf(inner.leftOperand, inner.rightOperand, outer.otherOperand),
+                    operations = listOf(op1, op2),
+                    hiddenOperationIndex = hiddenIndex,
+                    result = outer.result,
+                    grouping = grouping
+                )
+            } else {
+                val inner = buildBinaryOperation(config, op2)
+                val outer = buildOuterWithRightOperand(inner.result, op1, config) ?: return@repeat
+                return RandomOperationChallenge(
+                    operands = listOf(outer.otherOperand, inner.leftOperand, inner.rightOperand),
+                    operations = listOf(op1, op2),
+                    hiddenOperationIndex = hiddenIndex,
+                    result = outer.result,
+                    grouping = grouping
+                )
+            }
+        }
+
+        return buildSimple(config)
+    }
+
+    private fun shouldUseMultiStep(level: Int): Boolean {
+        val multiStepChance = when {
+            level <= 2 -> 0.0
+            level <= 4 -> 0.35
+            level <= 6 -> 0.6
+            else -> 0.8
+        }
+        return Random.nextDouble() < multiStepChance
+    }
+
+    private fun buildBinaryOperation(config: RandomOperationConfig, operation: Char): OperationResult {
         return when (operation) {
             '+' -> buildSum(config)
             '-' -> buildDifference(config)
@@ -17,32 +80,115 @@ class GenerateRandomOperationChallengeUseCase @Inject constructor() {
         }
     }
 
-    private fun buildSum(config: RandomOperationConfig): RandomOperationChallenge {
+    private fun buildSum(config: RandomOperationConfig): OperationResult {
         val first = Random.nextInt(config.min, config.max + 1)
         val second = Random.nextInt(config.min, config.max + 1)
-        return RandomOperationChallenge(first, second, first + second, '+')
+        return OperationResult(first, second, first + second)
     }
 
-    private fun buildDifference(config: RandomOperationConfig): RandomOperationChallenge {
+    private fun buildDifference(config: RandomOperationConfig): OperationResult {
         val first = Random.nextInt(config.min, config.max + 1)
         val second = Random.nextInt(config.min, first + 1)
-        return RandomOperationChallenge(first, second, first - second, '-')
+        return OperationResult(first, second, first - second)
     }
 
-    private fun buildMultiplication(config: RandomOperationConfig): RandomOperationChallenge {
+    private fun buildMultiplication(config: RandomOperationConfig): OperationResult {
         val highFirst = Random.nextInt(config.multMin, config.multHighMax + 1)
         val lowSecond = Random.nextInt(config.multMin, config.multLowMax + 1)
-        return RandomOperationChallenge(highFirst, lowSecond, highFirst * lowSecond, '*')
+        return OperationResult(highFirst, lowSecond, highFirst * lowSecond)
     }
 
-    private fun buildDivision(config: RandomOperationConfig): RandomOperationChallenge {
+    private fun buildDivision(config: RandomOperationConfig): OperationResult {
         val divisor = Random.nextInt(config.divMin, config.divLowMax + 1)
         val quotient = Random.nextInt(config.divMin, config.divHighMax + 1)
         val dividend = divisor * quotient
-        return RandomOperationChallenge(dividend, divisor, quotient, '/')
+        return OperationResult(dividend, divisor, quotient)
+    }
+
+    private fun buildOuterWithLeftOperand(
+        leftOperand: Int,
+        operation: Char,
+        config: RandomOperationConfig
+    ): OuterOperationResult? {
+        return when (operation) {
+            '+' -> {
+                val right = Random.nextInt(config.min, config.max + 1)
+                OuterOperationResult(right, leftOperand + right)
+            }
+
+            '-' -> {
+                if (leftOperand < config.min) return null
+                val maxRight = minOf(config.max, leftOperand)
+                if (maxRight < config.min) return null
+                val right = Random.nextInt(config.min, maxRight + 1)
+                OuterOperationResult(right, leftOperand - right)
+            }
+
+            '*' -> {
+                val right = Random.nextInt(config.multMin, config.multLowMax + 1)
+                OuterOperationResult(right, leftOperand * right)
+            }
+
+            '/' -> {
+                val divisor = pickDivisor(leftOperand, config) ?: return null
+                OuterOperationResult(divisor, leftOperand / divisor)
+            }
+
+            else -> null
+        }
+    }
+
+    private fun buildOuterWithRightOperand(
+        rightOperand: Int,
+        operation: Char,
+        config: RandomOperationConfig
+    ): OuterOperationResult? {
+        return when (operation) {
+            '+' -> {
+                val left = Random.nextInt(config.min, config.max + 1)
+                OuterOperationResult(left, left + rightOperand)
+            }
+
+            '-' -> {
+                val delta = Random.nextInt(config.min, config.max + 1)
+                val left = rightOperand + delta
+                OuterOperationResult(left, left - rightOperand)
+            }
+
+            '*' -> {
+                val left = Random.nextInt(config.multMin, config.multLowMax + 1)
+                OuterOperationResult(left, left * rightOperand)
+            }
+
+            '/' -> {
+                val quotient = Random.nextInt(config.divMin, config.divHighMax + 1)
+                val left = rightOperand * quotient
+                OuterOperationResult(left, left / rightOperand)
+            }
+
+            else -> null
+        }
+    }
+
+    private fun pickDivisor(value: Int, config: RandomOperationConfig): Int? {
+        if (value == 0) return null
+        val candidates = (config.divMin..config.divLowMax).filter { divisor -> value % divisor == 0 }
+        return candidates.randomOrNull()
     }
 
     companion object {
         private val OPERATIONS = listOf('+', '-', '*', '/')
+        private const val MAX_ATTEMPTS = 25
     }
+
+    private data class OperationResult(
+        val leftOperand: Int,
+        val rightOperand: Int,
+        val result: Int
+    )
+
+    private data class OuterOperationResult(
+        val otherOperand: Int,
+        val result: Int
+    )
 }

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_random_operation/presentation/components/RandomOperationChallengeCard.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_random_operation/presentation/components/RandomOperationChallengeCard.kt
@@ -21,6 +21,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import eu.indiewalkabout.mathbrainer.R
 import eu.indiewalkabout.mathbrainer.core.util.OperationFormatter
+import eu.indiewalkabout.mathbrainer.feat_games.feat_math_random_operation.domain.model.ExpressionGrouping
+import eu.indiewalkabout.mathbrainer.feat_games.feat_math_random_operation.domain.model.RandomOperationChallenge
 
 @Composable
 fun RandomOperationChallengeCard(
@@ -51,52 +53,14 @@ fun RandomOperationChallengeCard(
                 horizontalArrangement = Arrangement.Center,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                // First operand - always visible
                 Text(
-                    text = state.challenge.firstOperand.toString(),
+                    text = buildExpressionText(
+                        challenge = challenge,
+                        showAnswer = state.feedback != null
+                    ),
                     style = MaterialTheme.typography.displaySmall,
                     color = if (state.feedback != null) feedbackColor else MaterialTheme.colorScheme.onSurface,
                     fontWeight = if (state.feedback != null) FontWeight.Bold else FontWeight.Normal
-                )
-                
-                // Operation symbol - only shown after feedback
-                if (state.feedback != null) {
-                    Text(
-                        text = " ${OperationFormatter.format(challenge.correctOperation)} ",
-                        style = MaterialTheme.typography.displaySmall,
-                        color = feedbackColor,
-                        fontWeight = FontWeight.Bold
-                    )
-                } else {
-                    // Show question mark before answer
-                    Text(
-                        text = " ? ",
-                        style = MaterialTheme.typography.displaySmall,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        fontWeight = FontWeight.Bold
-                    )
-                }
-                
-                // Second operand - always visible
-                Text(
-                    text = state.challenge.secondOperand.toString(),
-                    style = MaterialTheme.typography.displaySmall,
-                    color = if (state.feedback != null) feedbackColor else MaterialTheme.colorScheme.onSurface,
-                    fontWeight = if (state.feedback != null) FontWeight.Bold else FontWeight.Normal
-                )
-                
-                // Equals and result - always visible
-                Text(
-                    text = " = ",
-                    style = MaterialTheme.typography.displaySmall,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    fontWeight = FontWeight.Normal
-                )
-                Text(
-                    text = challenge.result.toString(),
-                    style = MaterialTheme.typography.displaySmall,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    fontWeight = FontWeight.Normal
                 )
             }
 
@@ -121,4 +85,36 @@ fun RandomOperationChallengeCard(
             }
         }
     }
+}
+
+private fun buildExpressionText(
+    challenge: RandomOperationChallenge,
+    showAnswer: Boolean
+): String {
+    val operands = challenge.operands
+    val operations = challenge.operations
+    val hiddenIndex = challenge.hiddenOperationIndex
+    val displayedOperations = operations.mapIndexed { index, op ->
+        if (index == hiddenIndex) {
+            if (showAnswer) OperationFormatter.format(op) else "?"
+        } else {
+            OperationFormatter.format(op)
+        }
+    }
+
+    val expression = when (challenge.grouping) {
+        ExpressionGrouping.NONE -> {
+            "${operands[0]} ${displayedOperations[0]} ${operands[1]}"
+        }
+
+        ExpressionGrouping.LEFT -> {
+            "(${operands[0]} ${displayedOperations[0]} ${operands[1]}) ${displayedOperations[1]} ${operands[2]}"
+        }
+
+        ExpressionGrouping.RIGHT -> {
+            "${operands[0]} ${displayedOperations[0]} (${operands[1]} ${displayedOperations[1]} ${operands[2]})"
+        }
+    }
+
+    return "$expression = ${challenge.result}"
 }

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_random_operation/presentation/ui/RandomOperationViewModel.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_random_operation/presentation/ui/RandomOperationViewModel.kt
@@ -84,7 +84,8 @@ class RandomOperationViewModel @Inject constructor(
                 multHighMax = multiplicationConfig.maxOperandHigh,
                 divMin = divisionConfig.minOperand,
                 divLowMax = divisionConfig.maxOperandLow,
-                divHighMax = divisionConfig.maxOperandHigh
+                divHighMax = divisionConfig.maxOperandHigh,
+                level = _uiState.value.level
             )
         )
 


### PR DESCRIPTION
### Motivation
- Increase puzzle variety and difficulty progression in the random-operations game by adding multi-step equations and grouping. 
- Keep all generated operand values and results as integers (no fractional/div decimals). 
- Make puzzles more engaging by hiding a chosen operator and revealing it only after feedback. 

### Description
- Extended `RandomOperationConfig` with a `level` field and modified `RandomOperationViewModel` to pass `level` into the generator. 
- Replaced the simple `RandomOperationChallenge` shape with a multi-part model that stores `operands`, `operations`, `hiddenOperationIndex`, `result` and `grouping`, and exposes `correctOperation`. 
- Refactored `GenerateRandomOperationChallengeUseCase` to support both `buildSimple` (binary ops) and `buildMultiStep` (two-step expressions with `LEFT`/`RIGHT` grouping), adding helpers (`buildBinaryOperation`, `buildOuterWithLeftOperand`, `buildOuterWithRightOperand`, `pickDivisor`) that ensure integer-only results and respect configured ranges. 
- Updated the UI in `RandomOperationChallengeCard` to render full expressions (including parentheses for grouped expressions) and to show a `?` for the hidden operator until feedback is available. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ac9025afc832a9faf4094969f6588)