### PR TITLE
Remove redundant createRoute helpers for static game routes

### DIFF
--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/core/presentation/navigation/NavGraph.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/core/presentation/navigation/NavGraph.kt
@@ -57,17 +57,14 @@ fun NavGraph(
         composable(
             route = ScreenRoutes.MathWriteGame.route,
             arguments = listOf(
-                navArgument("operation") { type = NavType.StringType },
-                navArgument("highScore") { type = NavType.IntType }
+                navArgument("operation") { type = NavType.StringType }
             )
         ) { backStackEntry ->
             val encodedOperation = backStackEntry.arguments?.getString("operation") ?: "+"
             val operation = URLDecoder.decode(encodedOperation, "UTF-8")
-            val highScore = backStackEntry.arguments?.getInt("highScore") ?: 0
-            
+
             MathWriteGameScreen(
                 operation = operation,
-                initialHighScore = highScore,
                 onBack = { navController.popBackStack() }
             )
         }
@@ -76,136 +73,68 @@ fun NavGraph(
         composable(
             route = ScreenRoutes.MathChooseGame.route,
             arguments = listOf(
-                navArgument("operation") { type = NavType.StringType },
-                navArgument("highScore") { type = NavType.IntType }
+                navArgument("operation") { type = NavType.StringType }
             )
         ) { backStackEntry ->
             val encodedOperation = backStackEntry.arguments?.getString("operation") ?: "+"
             val operation = java.net.URLDecoder.decode(encodedOperation, "UTF-8")
-            val highScore = backStackEntry.arguments?.getInt("highScore") ?: 0
 
             MathChooseGameScreen(
                 operation = operation,
-                initialHighScore = highScore,
                 onBack = { navController.popBackStack() }
             )
         }
 
         // --- Double Number Game ---
-        composable(
-            route = ScreenRoutes.DoubleNumberGame.route,
-            arguments = listOf(
-                navArgument("highScore") { type = NavType.IntType }
-            )
-        ) { backStackEntry ->
-            val highScore = backStackEntry.arguments?.getInt("highScore") ?: 0
-
+        composable(route = ScreenRoutes.DoubleNumberGame.route) {
             DoubleNumberGameScreen(
-                initialHighScore = highScore,
                 onBack = { navController.popBackStack() }
             )
         }
 
         // --- Random Operation Game ---
-        composable(
-            route = ScreenRoutes.RandomOperationGame.route,
-            arguments = listOf(
-                navArgument("highScore") { type = NavType.IntType }
-            )
-        ) { backStackEntry ->
-            val highScore = backStackEntry.arguments?.getInt("highScore") ?: 0
-
+        composable(route = ScreenRoutes.RandomOperationGame.route) {
             RandomOperationGameScreen(
-                initialHighScore = highScore,
                 onBack = { navController.popBackStack() }
             )
         }
 
         // --- Memory Flash Game ---
-        composable(
-            route = ScreenRoutes.MemoryFlashGame.route,
-            arguments = listOf(
-                navArgument("highScore") { type = NavType.IntType }
-            )
-        ) { backStackEntry ->
-            val highScore = backStackEntry.arguments?.getInt("highScore") ?: 0
-
+        composable(route = ScreenRoutes.MemoryFlashGame.route) {
             MemoryFlashGameScreen(
-                initialHighScore = highScore,
                 onBack = { navController.popBackStack() }
             )
         }
 
         // --- Number Order Game ---
-        composable(
-            route = ScreenRoutes.NumberOrderGame.route,
-            arguments = listOf(
-                navArgument("highScore") { type = NavType.IntType }
-            )
-        ) { backStackEntry ->
-            val highScore = backStackEntry.arguments?.getInt("highScore") ?: 0
-
+        composable(route = ScreenRoutes.NumberOrderGame.route) {
             NumberOrderGameScreen(
-                initialHighScore = highScore,
                 onBack = { navController.popBackStack() }
             )
         }
 
         // --- Count Objects Game ---
-        composable(
-            route = ScreenRoutes.CountObjectsGame.route,
-            arguments = listOf(
-                navArgument("highScore") { type = NavType.IntType }
-            )
-        ) { backStackEntry ->
-            val highScore = backStackEntry.arguments?.getInt("highScore") ?: 0
-            CountObjectsGameScreen(
-                initialHighScore = highScore,
-                onBack = { navController.popBackStack() }
-            )
+        composable(route = ScreenRoutes.CountObjectsGame.route) {
+            CountObjectsGameScreen(onBack = { navController.popBackStack() })
         }
 
         // --- Sequence Completion Game ---
-        composable(
-            route = ScreenRoutes.SequenceCompleteGame.route,
-            arguments = listOf(
-                navArgument("highScore") { type = NavType.IntType }
-            )
-        ) { backStackEntry ->
-            val highScore = backStackEntry.arguments?.getInt("highScore") ?: 0
-
+        composable(route = ScreenRoutes.SequenceCompleteGame.route) {
             SequenceCompleteGameScreen(
-                initialHighScore = highScore,
                 onBack = { navController.popBackStack() }
             )
         }
 
         // --- Falling Operations Game ---
-        composable(
-            route = ScreenRoutes.FallingOpsGame.route,
-            arguments = listOf(
-                navArgument("highScore") { type = NavType.IntType }
-            )
-        ) { backStackEntry ->
-            val highScore = backStackEntry.arguments?.getInt("highScore") ?: 0
-
+        composable(route = ScreenRoutes.FallingOpsGame.route) {
             FallingOpsGameScreen(
-                initialHighScore = highScore,
                 onBack = { navController.popBackStack() }
             )
         }
 
         // --- Enigma Game ---
-        composable(
-            route = ScreenRoutes.EnigmaGame.route,
-            arguments = listOf(
-                navArgument("highScore") { type = NavType.IntType }
-            )
-        ) { backStackEntry ->
-            val highScore = backStackEntry.arguments?.getInt("highScore") ?: 0
-
+        composable(route = ScreenRoutes.EnigmaGame.route) {
             EnigmaGameScreen(
-                initialHighScore = highScore,
                 onBack = { navController.popBackStack() }
             )
         }

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/core/presentation/navigation/ScreenRoutes.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/core/presentation/navigation/ScreenRoutes.kt
@@ -4,44 +4,26 @@ import java.net.URLEncoder
 
 sealed class ScreenRoutes(val route: String) {
     object Home : ScreenRoutes("home")
-    object MathWriteGame : ScreenRoutes("math_write_game/{operation}/{highScore}") {
-        fun createRoute(operation: String, highScore: Int = 0): String {
+    object MathWriteGame : ScreenRoutes("math_write_game/{operation}") {
+        fun createRoute(operation: String): String {
             val encodedOperation = URLEncoder.encode(operation, "UTF-8")
-            return "math_write_game/$encodedOperation/$highScore"
+            return "math_write_game/$encodedOperation"
         }
     }
-    object MathChooseGame : ScreenRoutes("math_choose_game/{operation}/{highScore}") {
-        fun createRoute(operation: String, highScore: Int = 0): String {
+    object MathChooseGame : ScreenRoutes("math_choose_game/{operation}") {
+        fun createRoute(operation: String): String {
             val encodedOperation = URLEncoder.encode(operation, "UTF-8")
-            return "math_choose_game/$encodedOperation/$highScore"
+            return "math_choose_game/$encodedOperation"
         }
     }
-    object DoubleNumberGame : ScreenRoutes("double_game/{highScore}") {
-        fun createRoute(highScore: Int = 0): String = "double_game/$highScore"
-    }
-    object RandomOperationGame : ScreenRoutes("random_op_game/{highScore}") {
-        fun createRoute(highScore: Int = 0): String = "random_op_game/$highScore"
-    }
-    object MemoryFlashGame : ScreenRoutes("memory_flash_game/{highScore}") {
-        fun createRoute(highScore: Int = 0): String = "memory_flash_game/$highScore"
-    }
-    object CountObjectsGame : ScreenRoutes("count_objects_game/{highScore}") {
-        fun createRoute(highScore: Int = 0): String {
-            return "count_objects_game/$highScore"
-        }
-    }
-    object NumberOrderGame : ScreenRoutes("number_order_game/{highScore}") {
-        fun createRoute(highScore: Int = 0): String = "number_order_game/$highScore"
-    }
-    object SequenceCompleteGame : ScreenRoutes("sequence_complete_game/{highScore}") {
-        fun createRoute(highScore: Int = 0): String = "sequence_complete_game/$highScore"
-    }
-    object FallingOpsGame : ScreenRoutes("falling_ops_game/{highScore}") {
-        fun createRoute(highScore: Int = 0): String = "falling_ops_game/$highScore"
-    }
-    object EnigmaGame : ScreenRoutes("enigma_game/{highScore}") {
-        fun createRoute(highScore: Int = 0): String = "enigma_game/$highScore"
-    }
+    object DoubleNumberGame : ScreenRoutes("double_game")
+    object RandomOperationGame : ScreenRoutes("random_op_game")
+    object MemoryFlashGame : ScreenRoutes("memory_flash_game")
+    object CountObjectsGame : ScreenRoutes("count_objects_game")
+    object NumberOrderGame : ScreenRoutes("number_order_game")
+    object SequenceCompleteGame : ScreenRoutes("sequence_complete_game")
+    object FallingOpsGame : ScreenRoutes("falling_ops_game")
+    object EnigmaGame : ScreenRoutes("enigma_game")
     object GameSettings : ScreenRoutes("game_settings")
     object GameCredits : ScreenRoutes("game_credits")
     object Statistics : ScreenRoutes("statistics")

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_home/presentation/ui/HomeGameActivity.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_home/presentation/ui/HomeGameActivity.kt
@@ -20,11 +20,6 @@ class HomeGameActivity : ComponentActivity() {
             }
         }
     }
-
-    companion object {
-        const val OPERATION_KEY = "operation"
-        const val HIGHSCORE = "highscore"
-    }
 }
 
 

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_home/presentation/ui/HomeScreen.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_home/presentation/ui/HomeScreen.kt
@@ -140,8 +140,7 @@ fun HomeScreen(
                                 GameTypes.SUM_WRITE, GameTypes.DIFF_WRITE, GameTypes.MULT_WRITE, GameTypes.DIV_WRITE, GameTypes.MIX_WRITE -> {
                                     navController.navigate(
                                         ScreenRoutes.MathWriteGame.createRoute(
-                                            operation = game.definition.id,
-                                            highScore = game.highScore ?: 0
+                                            operation = game.definition.id
                                         )
                                     )
                                 }
@@ -149,73 +148,56 @@ fun HomeScreen(
                                 GameTypes.SUM_CHOOSE, GameTypes.DIFF_CHOOSE, GameTypes.MULT_CHOOSE, GameTypes.DIV_CHOOSE, GameTypes.MIX_CHOOSE -> {
                                     navController.navigate(
                                         ScreenRoutes.MathChooseGame.createRoute(
-                                            operation = game.definition.id,
-                                            highScore = game.highScore ?: 0
+                                            operation = game.definition.id
                                         )
                                     )
                                 }
 
                                 GameTypes.RANDOM_OPERATION -> {
                                     navController.navigate(
-                                        ScreenRoutes.RandomOperationGame.createRoute(
-                                            highScore = game.highScore ?: 0
-                                        )
+                                        ScreenRoutes.RandomOperationGame.route
                                     )
                                 }
 
                                 GameTypes.MEMORY_FLASH -> {
                                     navController.navigate(
-                                        ScreenRoutes.MemoryFlashGame.createRoute(
-                                            highScore = game.highScore ?: 0
-                                        )
+                                        ScreenRoutes.MemoryFlashGame.route
                                     )
                                 }
 
                                 GameTypes.DOUBLE_NUMBER -> {
                                     navController.navigate(
-                                        ScreenRoutes.DoubleNumberGame.createRoute(
-                                            highScore = game.highScore ?: 0
-                                        )
+                                        ScreenRoutes.DoubleNumberGame.route
                                     )
                                 }
 
                                 GameTypes.QUICK_COUNT -> {
                                     navController.navigate(
-                                        ScreenRoutes.CountObjectsGame.createRoute(
-                                            highScore = game.highScore ?: 0
-                                        )
+                                        ScreenRoutes.CountObjectsGame.route
                                     )
                                 }
 
                                 GameTypes.NUMBER_ORDER -> {
                                     navController.navigate(
-                                        ScreenRoutes.NumberOrderGame.createRoute(
-                                            highScore = game.highScore ?: 0
-                                        )
+                                        ScreenRoutes.NumberOrderGame.route
                                     )
                                 }
 
                                 GameTypes.SEQUENCE_COMPLETE -> {
                                     navController.navigate(
-                                        ScreenRoutes.SequenceCompleteGame.createRoute(
-                                            highScore = game.highScore ?: 0
-                                        )
+                                        ScreenRoutes.SequenceCompleteGame.route
                                     )
                                 }
 
                                 GameTypes.FALLING_OPS -> {
                                     navController.navigate(
-                                        ScreenRoutes.FallingOpsGame.createRoute(
-                                            highScore = game.highScore ?: 0
-                                        )
+                                        ScreenRoutes.FallingOpsGame.route
                                     )
                                 }
 
-			        GameTypes.ENIGMA -> {
+                                GameTypes.ENIGMA -> {
                                     navController.navigate(
-                                        ScreenRoutes.EnigmaGame.createRoute(
-                                            highScore = game.highScore ?: 0
-                                        )
+                                        ScreenRoutes.EnigmaGame.route
                                     )
                                 }
 

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_statistics/presentation/ui/StatisticScreen.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_statistics/presentation/ui/StatisticScreen.kt
@@ -112,8 +112,7 @@ fun StatisticScreen(
                                 GameTypes.SUM_WRITE, GameTypes.DIFF_WRITE, GameTypes.MULT_WRITE, GameTypes.DIV_WRITE, GameTypes.MIX_WRITE -> {
                                     navController.navigate(
                                         ScreenRoutes.MathWriteGame.createRoute(
-                                            operation = game.definition.id,
-                                            highScore = game.highScore ?: 0
+                                            operation = game.definition.id
                                         )
                                     )
                                 }
@@ -121,73 +120,56 @@ fun StatisticScreen(
                                 GameTypes.SUM_CHOOSE, GameTypes.DIFF_CHOOSE, GameTypes.MULT_CHOOSE, GameTypes.DIV_CHOOSE, GameTypes.MIX_CHOOSE -> {
                                     navController.navigate(
                                         ScreenRoutes.MathChooseGame.createRoute(
-                                            operation = game.definition.id,
-                                            highScore = game.highScore ?: 0
+                                            operation = game.definition.id
                                         )
                                     )
                                 }
 
                                 GameTypes.RANDOM_OPERATION -> {
                                     navController.navigate(
-                                        ScreenRoutes.RandomOperationGame.createRoute(
-                                            highScore = game.highScore ?: 0
-                                        )
+                                        ScreenRoutes.RandomOperationGame.route
                                     )
                                 }
 
                                 GameTypes.DOUBLE_NUMBER -> {
                                     navController.navigate(
-                                        ScreenRoutes.DoubleNumberGame.createRoute(
-                                            highScore = game.highScore ?: 0
-                                        )
+                                        ScreenRoutes.DoubleNumberGame.route
                                     )
                                 }
 
                                 GameTypes.QUICK_COUNT -> {
                                     navController.navigate(
-                                        ScreenRoutes.CountObjectsGame.createRoute(
-                                            highScore = game.highScore ?: 0
-                                        )
+                                        ScreenRoutes.CountObjectsGame.route
                                     )
                                 }
 
                                 GameTypes.NUMBER_ORDER -> {
                                     navController.navigate(
-                                        ScreenRoutes.NumberOrderGame.createRoute(
-                                            highScore = game.highScore ?: 0
-                                        )
+                                        ScreenRoutes.NumberOrderGame.route
                                     )
                                 }
 
                                 GameTypes.SEQUENCE_COMPLETE -> {
                                     navController.navigate(
-                                        ScreenRoutes.SequenceCompleteGame.createRoute(
-                                            highScore = game.highScore ?: 0
-                                        )
+                                        ScreenRoutes.SequenceCompleteGame.route
                                     )
                                 }
 
                                 GameTypes.FALLING_OPS -> {
                                     navController.navigate(
-                                        ScreenRoutes.FallingOpsGame.createRoute(
-                                            highScore = game.highScore ?: 0
-                                        )
+                                        ScreenRoutes.FallingOpsGame.route
                                     )
                                 }
 
                                 GameTypes.ENIGMA -> {
                                     navController.navigate(
-                                        ScreenRoutes.EnigmaGame.createRoute(
-                                            highScore = game.highScore ?: 0
-                                        )
+                                        ScreenRoutes.EnigmaGame.route
                                     )
                                 }
 
                                 GameTypes.MEMORY_FLASH -> {
                                     navController.navigate(
-                                        ScreenRoutes.MemoryFlashGame.createRoute(
-                                            highScore = game.highScore ?: 0
-                                        )
+                                        ScreenRoutes.MemoryFlashGame.route
                                     )
                                 }
 

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/navigation/ScreenRoutes.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/navigation/ScreenRoutes.kt
@@ -4,10 +4,10 @@ import java.net.URLEncoder
 
 sealed class ScreenRoutes(val route: String) {
     object Home : ScreenRoutes("home")
-    object MathWriteGame : ScreenRoutes("math_write_game/{operation}/{highScore}") {
-        fun createRoute(operation: String, highScore: Int = 0): String {
+    object MathWriteGame : ScreenRoutes("math_write_game/{operation}") {
+        fun createRoute(operation: String): String {
             val encodedOperation = URLEncoder.encode(operation, "UTF-8")
-            return "math_write_game/$encodedOperation/$highScore"
+            return "math_write_game/$encodedOperation"
         }
     }
 }


### PR DESCRIPTION
## Summary
- drop unnecessary createRoute helpers for static game routes that mirror base routes
- update home and statistics navigation to use the static route values directly
- retain parameterized route builders only where operations are encoded

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695241127348832a98526464fb0d387e)