### PR TITLE
Persist merged stats on game over

### DIFF
--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/core/presentation/GameStatsViewModel.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/core/presentation/GameStatsViewModel.kt
@@ -1,0 +1,33 @@
+package eu.indiewalkabout.mathbrainer.core.presentation
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import eu.indiewalkabout.mathbrainer.feat_home.domain.use_cases.GetGameStatsUseCase
+import eu.indiewalkabout.mathbrainer.feat_statistics.domain.model.GameStats
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class GameStatsViewModel @Inject constructor(
+    private val getGameStatsUseCase: GetGameStatsUseCase
+) : ViewModel() {
+
+    private val _gameStats = MutableStateFlow<Map<String, GameStats>>(emptyMap())
+    val gameStats: StateFlow<Map<String, GameStats>> = _gameStats.asStateFlow()
+
+    private var statsJob: Job? = null
+
+    fun refresh() {
+        statsJob?.cancel()
+        statsJob = viewModelScope.launch {
+            getGameStatsUseCase().collect { stats ->
+                _gameStats.value = stats
+            }
+        }
+    }
+}

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/core/presentation/navigation/NavGraph.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/core/presentation/navigation/NavGraph.kt
@@ -1,6 +1,5 @@
 package eu.indiewalkabout.mathbrainer.core.presentation.navigation
 
-import MathChooseGameScreen
 import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -14,10 +13,11 @@ import eu.indiewalkabout.mathbrainer.feat_credits.presentation.ui.GameCreditsScr
 import eu.indiewalkabout.mathbrainer.feat_games.feat_count_items.presentation.ui.CountObjectsGameScreen
 import eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.presentation.ui.EnigmaGameScreen
 import eu.indiewalkabout.mathbrainer.feat_games.feat_falling_op.presentation.ui.FallingOpsGameScreen
-import eu.indiewalkabout.mathbrainer.feat_games.feat_memory_flash.presentation.ui.MemoryFlashGameScreen
+import eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_choose.presentation.ui.MathChooseGameScreen
 import eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_double.presentation.ui.DoubleNumberGameScreen
 import eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_write.presentation.ui.MathWriteGameScreen
 import eu.indiewalkabout.mathbrainer.feat_games.feat_math_random_operation.presentation.ui.RandomOperationGameScreen
+import eu.indiewalkabout.mathbrainer.feat_games.feat_memory_flash.presentation.ui.MemoryFlashGameScreen
 import eu.indiewalkabout.mathbrainer.feat_games.feat_number_order.presentation.ui.NumberOrderGameScreen
 import eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.presentation.ui.SequenceCompleteGameScreen
 import eu.indiewalkabout.mathbrainer.feat_home.presentation.ui.HomeScreen

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_count_items/presentation/ui/CountObjectsGameScreen.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_count_items/presentation/ui/CountObjectsGameScreen.kt
@@ -48,6 +48,7 @@ import eu.indiewalkabout.mathbrainer.core.presentation.components.ResultBanner
 import eu.indiewalkabout.mathbrainer.core.presentation.state.ChallengeUiState
 import eu.indiewalkabout.mathbrainer.feat_games.feat_count_items.presentation.components.CountObjectsHeader
 import eu.indiewalkabout.mathbrainer.feat_games.feat_count_items.presentation.components.Placement
+import eu.indiewalkabout.mathbrainer.feat_home.domain.model.GameTypes
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlin.math.max
@@ -58,13 +59,23 @@ import kotlin.random.Random
 fun CountObjectsGameScreen(
     initialHighScore: Int = 0,
     onBack: () -> Unit,
-    viewModel: CountObjectsViewModel = hiltViewModel()
+    viewModel: CountObjectsViewModel = hiltViewModel(),
 ) {
-    val state by viewModel.uiState.collectAsState()
+    val gameId = GameTypes.QUICK_COUNT.id
+    val gameStats by viewModel.gameStats.collectAsState()
+    var hasStarted by remember(gameId) { mutableStateOf(false) }
 
-    LaunchedEffect(initialHighScore) {
-        viewModel.startGame(initialHighScore)
+    LaunchedEffect(gameId, initialHighScore) {
+        viewModel.refreshGameStat(gameId, initialHighScore)
     }
+
+    LaunchedEffect(gameId, gameStats) {
+        if (!hasStarted && gameStats != null) {
+            viewModel.startGame()
+            hasStarted = true
+        }
+    }
+    val state by viewModel.uiState.collectAsState()
 
     Scaffold(
         topBar = {

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_count_items/presentation/ui/CountObjectsViewModel.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_count_items/presentation/ui/CountObjectsViewModel.kt
@@ -9,6 +9,8 @@ import eu.indiewalkabout.mathbrainer.feat_games.feat_count_items.domain.use_case
 import eu.indiewalkabout.mathbrainer.feat_games.feat_count_items.domain.use_cases.UpdateCountObjectsScoreUseCase
 import eu.indiewalkabout.mathbrainer.feat_games.feat_count_items.presentation.state.CountObjectsUiState
 import eu.indiewalkabout.mathbrainer.feat_home.domain.model.GameTypes
+import eu.indiewalkabout.mathbrainer.feat_statistics.domain.model.GameStats
+import eu.indiewalkabout.mathbrainer.feat_statistics.domain.use_cases.GetGameStatsUseCase
 import eu.indiewalkabout.mathbrainer.feat_statistics.domain.use_cases.UpdateGameStatsUseCase
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -23,8 +25,18 @@ import javax.inject.Inject
 class CountObjectsViewModel @Inject constructor(
     private val generateCountObjectsChallengeUseCase: GenerateCountObjectsChallengeUseCase,
     private val updateCountObjectsScoreUseCase: UpdateCountObjectsScoreUseCase,
+    private val getGameStatsUseCase: GetGameStatsUseCase,
     private val updateGameStatsUseCase: UpdateGameStatsUseCase
 ) : ViewModel() {
+
+    private var highScore: Int = 0
+    private var challengesPlayed: Int = 0
+    private var challengesWon: Int = 0
+    private var challengesLost: Int = 0
+    private var lastLevel: Int = 1
+
+    private val _gameStats = MutableStateFlow<GameStats?>(null)
+    val gameStats: StateFlow<GameStats?> = _gameStats.asStateFlow()
 
     private var maxItemsToCount = INITIAL_MAX_ITEMS
     private var memorizeDuration = CountObjectsUiState.INITIAL_MEMORIZE_DURATION
@@ -35,16 +47,30 @@ class CountObjectsViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(CountObjectsUiState())
     val uiState: StateFlow<CountObjectsUiState> = _uiState.asStateFlow()
 
-    fun startGame(initialHighScore: Int = 0) {
-        _uiState.update { 
+    fun refreshGameStat(gameId: String, fallbackHighScore: Int = 0) {
+        viewModelScope.launch {
+            val stats = getGameStatsUseCase(gameId)
+            _gameStats.value = stats
+            highScore = stats?.highScore ?: fallbackHighScore
+            challengesPlayed = stats?.challengesPlayed ?: 0
+            challengesWon = stats?.challengesWon ?: 0
+            challengesLost = stats?.challengesLost ?: 0
+            lastLevel = stats?.lastLevel?.takeIf { it > 0 } ?: 1
+            _uiState.update { it.copy(highScore = highScore.takeIf { score -> score > 0 }) }
+        }
+    }
+
+    fun startGame() {
+        isScorePersisted = false
+        _uiState.update {
             it.copy(
-                highScore = initialHighScore.takeIf { score -> score > 0 },
+                highScore = highScore.takeIf { score -> score > 0 },
                 challengesPerLevel = INITIAL_CHALLENGES_PER_LEVEL,
                 challengesCompleted = 0,
                 level = 1,
                 score = 0,
                 lives = 3
-            ) 
+            )
         }
         viewModelScope.launch { launchNewChallenge(resetTimer = true) }
     }
@@ -102,6 +128,8 @@ class CountObjectsViewModel @Inject constructor(
     }
 
     private fun handleSuccess() {
+        challengesPlayed++
+        challengesWon++
         val newChallengesCompleted = _uiState.value.challengesCompleted + 1
         val newScore = _uiState.value.score + SCORE_INCREMENT
         var newLevel = _uiState.value.level
@@ -114,11 +142,13 @@ class CountObjectsViewModel @Inject constructor(
             updatedMemorizeDuration = memorizeDuration
         }
 
+        highScore = maxOf(highScore, newScore)
+        lastLevel = maxOf(lastLevel, newLevel)
         _uiState.update {
             it.copy(
                 feedback = ChallengeUiState.Feedback.SUCCESS,
                 score = newScore,
-                highScore = maxOf(it.highScore ?: 0, newScore),
+                highScore = highScore,
                 challengesCompleted = if (newChallengesCompleted >= it.challengesPerLevel) 0 else newChallengesCompleted,
                 memorizeDurationMs = updatedMemorizeDuration,
                 showNextButton = true,
@@ -136,6 +166,9 @@ class CountObjectsViewModel @Inject constructor(
 
     private fun handleFailure() {
         val remainingLives = _uiState.value.lives - 1
+        challengesPlayed++
+        challengesLost++
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
         _uiState.update {
             it.copy(
                 lives = remainingLives,
@@ -151,6 +184,7 @@ class CountObjectsViewModel @Inject constructor(
 
     private fun promoteLevel() {
         _uiState.update { it.copy(level = it.level + 1) }
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
         if (_uiState.value.level < LEVEL_ITEMS_CAP) {
             maxItemsToCount += ITEMS_INCREMENT
         }
@@ -167,13 +201,20 @@ class CountObjectsViewModel @Inject constructor(
         if (isScorePersisted) return
         isScorePersisted = true
         val finalScore = _uiState.value.score
+        highScore = maxOf(highScore, finalScore)
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
+        val updatedStats = GameStats(
+            gameId = GameTypes.QUICK_COUNT.id,
+            highScore = highScore,
+            challengesPlayed = challengesPlayed,
+            challengesWon = challengesWon,
+            challengesLost = challengesLost,
+            lastLevel = lastLevel
+        )
+        val previousStats = _gameStats.value
+        _gameStats.value = updatedStats
         viewModelScope.launch {
-            updateGameStatsUseCase(
-                gameId = GameTypes.QUICK_COUNT.id,
-                sessionScore = finalScore,
-                isWin = finalScore > 0,
-                lastLevel = _uiState.value.level
-            )
+            updateGameStatsUseCase(previousStats, updatedStats)
             if (finalScore > 0) {
                 updateCountObjectsScoreUseCase(finalScore)
             }

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/ui/EnigmaGameScreen.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/ui/EnigmaGameScreen.kt
@@ -19,6 +19,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -31,18 +33,30 @@ import eu.indiewalkabout.mathbrainer.core.presentation.components.keyboard.Keypa
 import eu.indiewalkabout.mathbrainer.core.presentation.state.ChallengeUiState
 import eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.presentation.components.EnigmaChallengeCard
 import eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.presentation.components.EnigmaHeader
+import eu.indiewalkabout.mathbrainer.feat_home.domain.model.GameTypes
 
 @Composable
 fun EnigmaGameScreen(
     initialHighScore: Int = 0,
     onBack: () -> Unit,
-    viewModel: EnigmaViewModel = hiltViewModel()
+    viewModel: EnigmaViewModel = hiltViewModel(),
 ) {
-    val state by viewModel.uiState.collectAsState()
+    val gameId = GameTypes.ENIGMA.id
+    val gameStats by viewModel.gameStats.collectAsState()
+    var hasStarted by remember(gameId) { mutableStateOf(false) }
 
-    LaunchedEffect(initialHighScore) {
-        viewModel.startGame(initialHighScore)
+    LaunchedEffect(gameId, initialHighScore) {
+        viewModel.refreshGameStat(gameId, initialHighScore)
     }
+
+    LaunchedEffect(gameId, gameStats) {
+        if (!hasStarted && gameStats != null) {
+            viewModel.startGame()
+            hasStarted = true
+        }
+    }
+
+    val state by viewModel.uiState.collectAsState()
 
     Scaffold(
         topBar = {

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/ui/EnigmaGameScreen.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/ui/EnigmaGameScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/ui/EnigmaViewModel.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_enigma/presentation/ui/EnigmaViewModel.kt
@@ -9,6 +9,8 @@ import eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.domain.use_cases.Gen
 import eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.domain.use_cases.UpdateEnigmaScoreUseCase
 import eu.indiewalkabout.mathbrainer.feat_games.feat_enigma.presentation.state.EnigmaUiState
 import eu.indiewalkabout.mathbrainer.feat_home.domain.model.GameTypes
+import eu.indiewalkabout.mathbrainer.feat_statistics.domain.model.GameStats
+import eu.indiewalkabout.mathbrainer.feat_statistics.domain.use_cases.GetGameStatsUseCase
 import eu.indiewalkabout.mathbrainer.feat_statistics.domain.use_cases.UpdateGameStatsUseCase
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -22,17 +24,40 @@ import javax.inject.Inject
 class EnigmaViewModel @Inject constructor(
     private val generateEnigmaChallengeUseCase: GenerateEnigmaChallengeUseCase,
     private val updateEnigmaScoreUseCase: UpdateEnigmaScoreUseCase,
+    private val getGameStatsUseCase: GetGameStatsUseCase,
     private val updateGameStatsUseCase: UpdateGameStatsUseCase
 ) : ViewModel() {
+
+    private var highScore: Int = 0
+    private var challengesPlayed: Int = 0
+    private var challengesWon: Int = 0
+    private var challengesLost: Int = 0
+    private var lastLevel: Int = 1
+
+    private val _gameStats = MutableStateFlow<GameStats?>(null)
+    val gameStats: StateFlow<GameStats?> = _gameStats.asStateFlow()
 
     private var isScorePersisted = false
 
     private val _uiState = MutableStateFlow(EnigmaUiState())
     val uiState: StateFlow<EnigmaUiState> = _uiState.asStateFlow()
 
-    fun startGame(initialHighScore: Int = 0) {
+    fun refreshGameStat(gameId: String, fallbackHighScore: Int = 0) {
+        viewModelScope.launch {
+            val stats = getGameStatsUseCase(gameId)
+            _gameStats.value = stats
+            highScore = stats?.highScore ?: fallbackHighScore
+            challengesPlayed = stats?.challengesPlayed ?: 0
+            challengesWon = stats?.challengesWon ?: 0
+            challengesLost = stats?.challengesLost ?: 0
+            lastLevel = stats?.lastLevel?.takeIf { it > 0 } ?: 1
+            _uiState.update { it.copy(highScore = highScore.takeIf { score -> score > 0 }) }
+        }
+    }
+
+    fun startGame() {
         isScorePersisted = false
-        _uiState.update { it.copy(highScore = initialHighScore.takeIf { score -> score > 0 }) }
+        _uiState.update { it.copy(highScore = highScore.takeIf { score -> score > 0 }) }
         launchNewChallenge()
     }
 
@@ -85,14 +110,18 @@ class EnigmaViewModel @Inject constructor(
 
 
     private fun handleSuccess() {
+        challengesPlayed++
+        challengesWon++
         promoteLevel()
         val newScore = _uiState.value.score + SCORE_INCREMENT
 
+        highScore = maxOf(highScore, newScore)
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
         _uiState.update {
             it.copy(
                 feedback = ChallengeUiState.Feedback.SUCCESS,
                 score = newScore,
-                highScore = maxOf(it.highScore ?: 0, newScore),
+                highScore = highScore,
             )
         }
         startDelayedChallenge()
@@ -100,6 +129,9 @@ class EnigmaViewModel @Inject constructor(
 
     private fun handleFailure() {
         val remainingLives = _uiState.value.lives - 1
+        challengesPlayed++
+        challengesLost++
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
         _uiState.update { it.copy(lives = remainingLives, feedback = ChallengeUiState.Feedback.FAILURE) }
 
         if (remainingLives <= 0) {
@@ -121,6 +153,7 @@ class EnigmaViewModel @Inject constructor(
 
     private fun promoteLevel() {
         _uiState.update { it.copy(level = it.level + 1) }
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
     }
 
     private fun onGameOver() {
@@ -132,18 +165,20 @@ class EnigmaViewModel @Inject constructor(
         if (isScorePersisted) return
         isScorePersisted = true
         val finalScore = _uiState.value.score
+        highScore = maxOf(highScore, finalScore)
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
+        val updatedStats = GameStats(
+            gameId = GameTypes.ENIGMA.id,
+            highScore = highScore,
+            challengesPlayed = challengesPlayed,
+            challengesWon = challengesWon,
+            challengesLost = challengesLost,
+            lastLevel = lastLevel
+        )
+        val previousStats = _gameStats.value
+        _gameStats.value = updatedStats
         viewModelScope.launch {
-            if (finalScore > 0) {
-                updateEnigmaScoreUseCase(finalScore)
-            }
-        }
-        viewModelScope.launch {
-            updateGameStatsUseCase(
-                gameId = GameTypes.ENIGMA.id,
-                sessionScore = finalScore,
-                isWin = finalScore > 0,
-                lastLevel = _uiState.value.level
-            )
+            updateGameStatsUseCase(previousStats, updatedStats)
             if (finalScore > 0) {
                 updateEnigmaScoreUseCase(finalScore)
             }

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_falling_op/presentation/ui/FallingOpsGameScreen.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_falling_op/presentation/ui/FallingOpsGameScreen.kt
@@ -27,6 +27,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
@@ -38,6 +40,7 @@ import eu.indiewalkabout.mathbrainer.R
 import eu.indiewalkabout.mathbrainer.core.presentation.components.GameOverDialog
 import eu.indiewalkabout.mathbrainer.feat_games.feat_falling_op.presentation.components.FallingOpsHeader
 import eu.indiewalkabout.mathbrainer.feat_games.feat_falling_op.presentation.components.FallingOpsKeypad
+import eu.indiewalkabout.mathbrainer.feat_home.domain.model.GameTypes
 import kotlin.math.roundToInt
 
 @SuppressLint("UnusedBoxWithConstraintsScope")
@@ -45,10 +48,21 @@ import kotlin.math.roundToInt
 fun FallingOpsGameScreen(
     initialHighScore: Int = 0,
     onBack: () -> Unit,
-    viewModel: FallingOpsViewModel = hiltViewModel()
+    viewModel: FallingOpsViewModel = hiltViewModel(),
 ) {
-    LaunchedEffect(initialHighScore) {
-        viewModel.startGame(initialHighScore)
+    val gameId = GameTypes.FALLING_OPS.id
+    val gameStats by viewModel.gameStats.collectAsState()
+    var hasStarted by remember(gameId) { mutableStateOf(false) }
+
+    LaunchedEffect(gameId, initialHighScore) {
+        viewModel.refreshGameStat(gameId, initialHighScore)
+    }
+
+    LaunchedEffect(gameId, gameStats) {
+        if (!hasStarted && gameStats != null) {
+            viewModel.startGame()
+            hasStarted = true
+        }
     }
 
     val state by viewModel.uiState.collectAsState()

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_falling_op/presentation/ui/FallingOpsGameScreen.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_falling_op/presentation/ui/FallingOpsGameScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_falling_op/presentation/ui/FallingOpsViewModel.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_falling_op/presentation/ui/FallingOpsViewModel.kt
@@ -9,6 +9,8 @@ import eu.indiewalkabout.mathbrainer.feat_games.feat_falling_op.domain.use_cases
 import eu.indiewalkabout.mathbrainer.feat_games.feat_falling_op.presentation.state.FallingOperationItem
 import eu.indiewalkabout.mathbrainer.feat_games.feat_falling_op.presentation.state.FallingOpsUiState
 import eu.indiewalkabout.mathbrainer.feat_home.domain.model.GameTypes
+import eu.indiewalkabout.mathbrainer.feat_statistics.domain.model.GameStats
+import eu.indiewalkabout.mathbrainer.feat_statistics.domain.use_cases.GetGameStatsUseCase
 import eu.indiewalkabout.mathbrainer.feat_statistics.domain.use_cases.UpdateGameStatsUseCase
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -26,8 +28,18 @@ import kotlin.random.Random
 class FallingOpsViewModel @Inject constructor(
     private val generateFallingOperationUseCase: GenerateFallingOperationUseCase,
     private val updateFallingOpsScoreUseCase: UpdateFallingOpsScoreUseCase,
+    private val getGameStatsUseCase: GetGameStatsUseCase,
     private val updateGameStatsUseCase: UpdateGameStatsUseCase
 ) : ViewModel() {
+
+    private var highScore: Int = 0
+    private var challengesPlayed: Int = 0
+    private var challengesWon: Int = 0
+    private var challengesLost: Int = 0
+    private var lastLevel: Int = 1
+
+    private val _gameStats = MutableStateFlow<GameStats?>(null)
+    val gameStats: StateFlow<GameStats?> = _gameStats.asStateFlow()
 
     private val _uiState = MutableStateFlow(FallingOpsUiState())
     val uiState: StateFlow<FallingOpsUiState> = _uiState.asStateFlow()
@@ -39,13 +51,26 @@ class FallingOpsViewModel @Inject constructor(
     private var spawnIntervalMs = BASE_SPAWN_INTERVAL_MS
     private var isScorePersisted = false
 
+    fun refreshGameStat(gameId: String, fallbackHighScore: Int = 0) {
+        viewModelScope.launch {
+            val stats = getGameStatsUseCase(gameId)
+            _gameStats.value = stats
+            highScore = stats?.highScore ?: fallbackHighScore
+            challengesPlayed = stats?.challengesPlayed ?: 0
+            challengesWon = stats?.challengesWon ?: 0
+            challengesLost = stats?.challengesLost ?: 0
+            lastLevel = stats?.lastLevel?.takeIf { it > 0 } ?: 1
+            _uiState.update { it.copy(highScore = highScore.takeIf { score -> score > 0 }) }
+        }
+    }
+
     fun startGame(initialHighScore: Int = 0) {
         stopJobs()
         isScorePersisted = false
         nextId = 0
         updateDifficulty(level = 1)
         _uiState.value = FallingOpsUiState(
-            highScore = initialHighScore.takeIf { it > 0 }
+            highScore = highScore.takeIf { score -> score > 0 } ?: initialHighScore.takeIf { it > 0 }
         )
         addOperation()
         startFallingLoop()
@@ -76,6 +101,9 @@ class FallingOpsViewModel @Inject constructor(
 
         val matches = _uiState.value.operations.filter { it.definition.result == inputValue }
         if (matches.isEmpty()) {
+            challengesPlayed++
+            challengesLost++
+            lastLevel = maxOf(lastLevel, _uiState.value.level)
             _uiState.update {
                 it.copy(
                     input = "",
@@ -94,18 +122,24 @@ class FallingOpsViewModel @Inject constructor(
         var explodedThisLevel = updatedExploded
         var updatedOperations = remaining
 
+        challengesPlayed++
+        challengesWon++
+
         if (updatedExploded >= _uiState.value.targetPerLevel) {
             updatedLevel += 1
             updatedTarget = _uiState.value.targetPerLevel + TARGET_INCREMENT
             explodedThisLevel = 0
             updatedOperations = emptyList()
             updateDifficulty(updatedLevel)
+            lastLevel = maxOf(lastLevel, updatedLevel)
         }
+
+        highScore = maxOf(highScore, updatedScore)
 
         _uiState.update {
             it.copy(
                 score = updatedScore,
-                highScore = maxOf(it.highScore ?: 0, updatedScore),
+                highScore = highScore,
                 operations = updatedOperations,
                 explodedThisLevel = explodedThisLevel,
                 level = updatedLevel,
@@ -170,6 +204,9 @@ class FallingOpsViewModel @Inject constructor(
 
     private fun handleLifeLost() {
         val remainingLives = _uiState.value.lives - 1
+        challengesPlayed++
+        challengesLost++
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
         _uiState.update {
             it.copy(
                 lives = remainingLives,
@@ -193,13 +230,20 @@ class FallingOpsViewModel @Inject constructor(
         if (isScorePersisted) return
         isScorePersisted = true
         val finalScore = _uiState.value.score
+        highScore = maxOf(highScore, finalScore)
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
+        val updatedStats = GameStats(
+            gameId = GameTypes.FALLING_OPS.id,
+            highScore = highScore,
+            challengesPlayed = challengesPlayed,
+            challengesWon = challengesWon,
+            challengesLost = challengesLost,
+            lastLevel = lastLevel
+        )
+        val previousStats = _gameStats.value
+        _gameStats.value = updatedStats
         viewModelScope.launch {
-            updateGameStatsUseCase(
-                gameId = GameTypes.FALLING_OPS.id,
-                sessionScore = finalScore,
-                isWin = finalScore > 0,
-                lastLevel = _uiState.value.level
-            )
+            updateGameStatsUseCase(previousStats, updatedStats)
             if (finalScore > 0) {
                 updateFallingOpsScoreUseCase(finalScore)
             }

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_op_choose/presentation/ui/MathChooseGameScreen.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_op_choose/presentation/ui/MathChooseGameScreen.kt
@@ -1,3 +1,5 @@
+package eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_choose.presentation.ui
+
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -17,6 +19,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -35,8 +39,19 @@ fun MathChooseGameScreen(
     onBack: () -> Unit,
     viewModel: MathOpChooseResultViewModel = hiltViewModel()
 ) {
-    LaunchedEffect(operation, initialHighScore) {
-        viewModel.setOperation(operation, initialHighScore)
+    val gameId = operation
+    val gameStats by viewModel.gameStats.collectAsState()
+    var hasStarted by remember(gameId) { mutableStateOf(false) }
+
+    LaunchedEffect(gameId, initialHighScore) {
+        viewModel.refreshGameStat(gameId, initialHighScore)
+    }
+
+    LaunchedEffect(gameId, gameStats) {
+        if (!hasStarted && gameStats != null) {
+            viewModel.setOperation(gameId)
+            hasStarted = true
+        }
     }
 
     val state by viewModel.uiState.collectAsState()

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_op_choose/presentation/ui/MathChooseGameScreen.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_op_choose/presentation/ui/MathChooseGameScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -30,7 +31,6 @@ import eu.indiewalkabout.mathbrainer.R
 import eu.indiewalkabout.mathbrainer.core.presentation.components.GameOverDialog
 import eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_choose.presentation.components.ChooseChallengeCard
 import eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_choose.presentation.components.ChooseHeaderInfo
-import eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_choose.presentation.ui.MathOpChooseResultViewModel
 
 @Composable
 fun MathChooseGameScreen(

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_op_choose/presentation/ui/MathOpChooseResultViewModel.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_op_choose/presentation/ui/MathOpChooseResultViewModel.kt
@@ -10,6 +10,8 @@ import eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_choose.domain.model
 import eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_choose.domain.use_cases.GenerateMathChooseChallengeUseCase
 import eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_choose.domain.use_cases.UpdateChooseResultScoreUseCase
 import eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_choose.presentation.state.MathChooseUiState
+import eu.indiewalkabout.mathbrainer.feat_statistics.domain.model.GameStats
+import eu.indiewalkabout.mathbrainer.feat_statistics.domain.use_cases.GetGameStatsUseCase
 import eu.indiewalkabout.mathbrainer.feat_statistics.domain.use_cases.UpdateGameStatsUseCase
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -24,11 +26,19 @@ import javax.inject.Inject
 class MathOpChooseResultViewModel @Inject constructor(
     private val generateMathChooseChallengeUseCase: GenerateMathChooseChallengeUseCase,
     private val updateChooseResultScoreUseCase: UpdateChooseResultScoreUseCase,
+    private val getGameStatsUseCase: GetGameStatsUseCase,
     private val updateGameStatsUseCase: UpdateGameStatsUseCase
 ) : ViewModel() {
 
     private var operationParam: String = ""
-    private var initialHighScore: Int? = null
+    private var highScore: Int = 0
+    private var challengesPlayed: Int = 0
+    private var challengesWon: Int = 0
+    private var challengesLost: Int = 0
+    private var lastLevel: Int = 1
+
+    private val _gameStats = MutableStateFlow<GameStats?>(null)
+    val gameStats: StateFlow<GameStats?> = _gameStats.asStateFlow()
 
     private var scoreCategory = ChooseResultScoreCategory.fromOperation(operationParam)
 
@@ -57,15 +67,29 @@ class MathOpChooseResultViewModel @Inject constructor(
     private var isScorePersisted = false // flag to prevent double writes to the DB
 
     // game state
-    private val _uiState = MutableStateFlow(MathChooseUiState(highScore = initialHighScore))
+    private val _uiState = MutableStateFlow(MathChooseUiState())
     val uiState: StateFlow<MathChooseUiState> = _uiState.asStateFlow()
 
-    fun setOperation(operation: String, highScore: Int = 0) {
-        operationParam = operation
-        initialHighScore = highScore.takeIf { it > 0 }
-        scoreCategory = ChooseResultScoreCategory.fromOperation(operationParam)
-        _uiState.update { it.copy(highScore = initialHighScore) }
+    fun refreshGameStat(gameId: String, fallbackHighScore: Int = 0) {
         viewModelScope.launch {
+            operationParam = gameId
+            val stats = getGameStatsUseCase(gameId)
+            _gameStats.value = stats
+            highScore = stats?.highScore ?: fallbackHighScore
+            challengesPlayed = stats?.challengesPlayed ?: 0
+            challengesWon = stats?.challengesWon ?: 0
+            challengesLost = stats?.challengesLost ?: 0
+            lastLevel = stats?.lastLevel?.takeIf { it > 0 } ?: 1
+            _uiState.update { it.copy(highScore = highScore.takeIf { score -> score > 0 }) }
+        }
+    }
+
+    fun setOperation(operation: String) {
+        operationParam = operation
+        scoreCategory = ChooseResultScoreCategory.fromOperation(operationParam)
+        isScorePersisted = false
+        viewModelScope.launch {
+            _uiState.update { it.copy(highScore = highScore.takeIf { score -> score > 0 }) }
             launchNewChallenge(resetTimer = true)
         }
     }
@@ -132,6 +156,8 @@ class MathOpChooseResultViewModel @Inject constructor(
 
     private fun handleSuccess() {
         challengesCompleted++
+        challengesPlayed++
+        challengesWon++
         val newScore = _uiState.value.score + SCORE_INCREMENT
         var updatedTimer = timerLength
 
@@ -141,11 +167,13 @@ class MathOpChooseResultViewModel @Inject constructor(
             updatedTimer = timerLength
         }
 
+        highScore = maxOf(highScore, newScore)
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
         _uiState.update {
             it.copy(
                 feedback = ChallengeUiState.Feedback.SUCCESS,
                 score = newScore,
-                highScore = maxOf(it.highScore ?: 0, newScore),
+                highScore = highScore,
                 challengesCompleted = challengesCompleted,
                 challengesPerLevel = challengesPerLevel,
                 timeRemaining = updatedTimer,
@@ -157,6 +185,9 @@ class MathOpChooseResultViewModel @Inject constructor(
 
     private fun handleFailure() {
         val remainingLives = _uiState.value.lives - 1
+        challengesPlayed++
+        challengesLost++
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
         _uiState.update {
             it.copy(
                 lives = remainingLives,
@@ -173,6 +204,9 @@ class MathOpChooseResultViewModel @Inject constructor(
 
     private fun handleCountdownExpired() {
         val remainingLives = _uiState.value.lives - 1
+        challengesPlayed++
+        challengesLost++
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
         _uiState.update { it.copy(lives = remainingLives, feedback = ChallengeUiState.Feedback.FAILURE, timeRemaining = 0L) }
         if (remainingLives <= 0) {
             onGameOver()
@@ -192,6 +226,7 @@ class MathOpChooseResultViewModel @Inject constructor(
 
     private fun promoteLevel() {
         _uiState.update { it.copy(level = it.level + 1) }
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
         operandRangeMin = operandRangeMax
         operandRangeMax = 100 * _uiState.value.level + 50 * (_uiState.value.level - 1)
         multiplicationConfig.maxOperandHigh += 5
@@ -214,15 +249,22 @@ class MathOpChooseResultViewModel @Inject constructor(
         if (isScorePersisted) return
         isScorePersisted = true
         val finalScore = _uiState.value.score
+        highScore = maxOf(highScore, finalScore)
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
+        val updatedStats = GameStats(
+            gameId = operationParam,
+            highScore = highScore,
+            challengesPlayed = challengesPlayed,
+            challengesWon = challengesWon,
+            challengesLost = challengesLost,
+            lastLevel = lastLevel
+        )
+        val previousStats = _gameStats.value
+        _gameStats.value = updatedStats
         viewModelScope.launch {
-            updateGameStatsUseCase(
-                gameId = operationParam,
-                sessionScore = finalScore,
-                isWin = finalScore > 0,
-                lastLevel = _uiState.value.level
-            )
+            updateGameStatsUseCase(previousStats, updatedStats)
             if (finalScore > 0) {
-                updateChooseResultScoreUseCase(scoreCategory,finalScore)
+                updateChooseResultScoreUseCase(scoreCategory, finalScore)
             }
         }
     }

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_op_double/presentation/ui/DoubleNumberGameScreen.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_op_double/presentation/ui/DoubleNumberGameScreen.kt
@@ -19,6 +19,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -29,15 +31,27 @@ import eu.indiewalkabout.mathbrainer.core.presentation.components.GameOverDialog
 import eu.indiewalkabout.mathbrainer.core.presentation.components.keyboard.Keypad
 import eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_double.presentation.components.DoubleNumberChallengeCard
 import eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_double.presentation.components.DoubleNumberHeader
+import eu.indiewalkabout.mathbrainer.feat_home.domain.model.GameTypes
 
 @Composable
 fun DoubleNumberGameScreen(
     initialHighScore: Int = 0,
     onBack: () -> Unit,
-    viewModel: DoubleNumberViewModel = hiltViewModel()
+    viewModel: DoubleNumberViewModel = hiltViewModel(),
 ) {
-    LaunchedEffect(initialHighScore) {
-        viewModel.startGame(initialHighScore)
+    val gameId = GameTypes.DOUBLE_NUMBER.id
+    val gameStats by viewModel.gameStats.collectAsState()
+    var hasStarted by remember(gameId) { mutableStateOf(false) }
+
+    LaunchedEffect(gameId, initialHighScore) {
+        viewModel.refreshGameStat(gameId, initialHighScore)
+    }
+
+    LaunchedEffect(gameId, gameStats) {
+        if (!hasStarted && gameStats != null) {
+            viewModel.startGame()
+            hasStarted = true
+        }
     }
 
     val state by viewModel.uiState.collectAsState()

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_op_double/presentation/ui/DoubleNumberGameScreen.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_op_double/presentation/ui/DoubleNumberGameScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_op_double/presentation/ui/DoubleNumberViewModel.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_op_double/presentation/ui/DoubleNumberViewModel.kt
@@ -9,6 +9,8 @@ import eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_double.domain.use_c
 import eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_double.domain.use_cases.UpdateDoubleNumberScoreUseCase
 import eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_double.presentation.state.DoubleNumberUiState
 import eu.indiewalkabout.mathbrainer.feat_home.domain.model.GameTypes
+import eu.indiewalkabout.mathbrainer.feat_statistics.domain.model.GameStats
+import eu.indiewalkabout.mathbrainer.feat_statistics.domain.use_cases.GetGameStatsUseCase
 import eu.indiewalkabout.mathbrainer.feat_statistics.domain.use_cases.UpdateGameStatsUseCase
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -23,8 +25,18 @@ import javax.inject.Inject
 class DoubleNumberViewModel @Inject constructor(
     private val generateDoubleNumberChallengeUseCase: GenerateDoubleNumberChallengeUseCase,
     private val updateDoubleNumberScoreUseCase: UpdateDoubleNumberScoreUseCase,
+    private val getGameStatsUseCase: GetGameStatsUseCase,
     private val updateGameStatsUseCase: UpdateGameStatsUseCase
 ) : ViewModel() {
+
+    private var highScore: Int = 0
+    private var challengesPlayed: Int = 0
+    private var challengesWon: Int = 0
+    private var challengesLost: Int = 0
+    private var lastLevel: Int = 1
+
+    private val _gameStats = MutableStateFlow<GameStats?>(null)
+    val gameStats: StateFlow<GameStats?> = _gameStats.asStateFlow()
 
     private var operandRangeMin = 1
     private var operandRangeMax = 100
@@ -37,8 +49,22 @@ class DoubleNumberViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(DoubleNumberUiState())
     val uiState: StateFlow<DoubleNumberUiState> = _uiState.asStateFlow()
 
+    fun refreshGameStat(gameId: String, fallbackHighScore: Int = 0) {
+        viewModelScope.launch {
+            val stats = getGameStatsUseCase(gameId)
+            _gameStats.value = stats
+            highScore = stats?.highScore ?: fallbackHighScore
+            challengesPlayed = stats?.challengesPlayed ?: 0
+            challengesWon = stats?.challengesWon ?: 0
+            challengesLost = stats?.challengesLost ?: 0
+            lastLevel = stats?.lastLevel?.takeIf { it > 0 } ?: 1
+            _uiState.update { it.copy(highScore = highScore.takeIf { score -> score > 0 }) }
+        }
+    }
+
     fun startGame(initialHighScore: Int = 0) {
-        _uiState.update { it.copy(highScore = initialHighScore.takeIf { score -> score > 0 }) }
+        isScorePersisted = false
+        _uiState.update { it.copy(highScore = highScore.takeIf { score -> score > 0 } ?: initialHighScore.takeIf { it > 0 }) }
         viewModelScope.launch {
             launchNewChallenge(resetTimer = true)
         }
@@ -110,6 +136,8 @@ class DoubleNumberViewModel @Inject constructor(
     }
 
     private fun handleSuccess() {
+        challengesPlayed++
+        challengesWon++
         challengesCompleted++
         val newScore = _uiState.value.score + SCORE_INCREMENT
         var updatedTimer = timerLength
@@ -120,11 +148,13 @@ class DoubleNumberViewModel @Inject constructor(
             updatedTimer = timerLength
         }
 
+        highScore = maxOf(highScore, newScore)
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
         _uiState.update {
             it.copy(
                 feedback = ChallengeUiState.Feedback.SUCCESS,
                 score = newScore,
-                highScore = maxOf(it.highScore ?: 0, newScore),
+                highScore = highScore,
                 challengesCompleted = challengesCompleted,
                 timeRemaining = updatedTimer,
                 totalTime = updatedTimer
@@ -135,6 +165,9 @@ class DoubleNumberViewModel @Inject constructor(
 
     private fun handleFailure() {
         val remainingLives = _uiState.value.lives - 1
+        challengesPlayed++
+        challengesLost++
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
         _uiState.update {
             it.copy(
                 lives = remainingLives,
@@ -151,6 +184,9 @@ class DoubleNumberViewModel @Inject constructor(
 
     private fun handleCountdownExpired() {
         val remainingLives = _uiState.value.lives - 1
+        challengesPlayed++
+        challengesLost++
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
         _uiState.update {
             it.copy(
                 lives = remainingLives,
@@ -176,6 +212,7 @@ class DoubleNumberViewModel @Inject constructor(
 
     private fun promoteLevel() {
         _uiState.update { it.copy(level = it.level + 1) }
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
         operandRangeMin = operandRangeMax
         operandRangeMax = 100 * _uiState.value.level + 50 * (_uiState.value.level - 1)
         timerLength += LEVEL_TIMER_INCREMENT
@@ -191,13 +228,20 @@ class DoubleNumberViewModel @Inject constructor(
         if (isScorePersisted) return
         isScorePersisted = true
         val finalScore = _uiState.value.score
+        highScore = maxOf(highScore, finalScore)
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
+        val updatedStats = GameStats(
+            gameId = GameTypes.DOUBLE_NUMBER.id,
+            highScore = highScore,
+            challengesPlayed = challengesPlayed,
+            challengesWon = challengesWon,
+            challengesLost = challengesLost,
+            lastLevel = lastLevel
+        )
+        val previousStats = _gameStats.value
+        _gameStats.value = updatedStats
         viewModelScope.launch {
-            updateGameStatsUseCase(
-                gameId = GameTypes.DOUBLE_NUMBER.id,
-                sessionScore = finalScore,
-                isWin = finalScore > 0,
-                lastLevel = _uiState.value.level
-            )
+            updateGameStatsUseCase(previousStats, updatedStats)
             if (finalScore > 0) {
                 updateDoubleNumberScoreUseCase(finalScore)
             }

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_op_write/presentation/ui/MathOpWriteResultViewModel.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_op_write/presentation/ui/MathOpWriteResultViewModel.kt
@@ -1,6 +1,5 @@
 package eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_write.presentation.ui
 
-
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -11,6 +10,8 @@ import eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_write.domain.model.
 import eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_write.domain.use_cases.GenerateMathWriteChallengeUseCase
 import eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_write.domain.use_cases.UpdateWriteResultScoreUseCase
 import eu.indiewalkabout.mathbrainer.feat_games.feat_math_op_write.presentation.state.MathWriteUiState
+import eu.indiewalkabout.mathbrainer.feat_statistics.domain.model.GameStats
+import eu.indiewalkabout.mathbrainer.feat_statistics.domain.use_cases.GetGameStatsUseCase
 import eu.indiewalkabout.mathbrainer.feat_statistics.domain.use_cases.UpdateGameStatsUseCase
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -21,15 +22,23 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-    @HiltViewModel
+@HiltViewModel
 class MathOpWriteResultViewModel @Inject constructor(
     private val generateMathWriteChallengeUseCase: GenerateMathWriteChallengeUseCase,
     private val updateGameStatsUseCase: UpdateGameStatsUseCase,
+    private val getGameStatsUseCase: GetGameStatsUseCase,
     private val updateWriteResultScoreUseCase: UpdateWriteResultScoreUseCase
 ) : ViewModel() {
 
     private var operationParam: String = ""
-    private var initialHighScore: Int? = null
+    private var highScore: Int = 0
+    private var challengesPlayed: Int = 0
+    private var challengesWon: Int = 0
+    private var challengesLost: Int = 0
+    private var lastLevel: Int = 1
+
+    private val _gameStats = MutableStateFlow<GameStats?>(null)
+    val gameStats: StateFlow<GameStats?> = _gameStats.asStateFlow()
 
     // score category for saving score
     private val scoreCategory: WriteResultScoreCategory
@@ -60,15 +69,28 @@ class MathOpWriteResultViewModel @Inject constructor(
     private var isScorePersisted = false // flag to prevent double writes to the DB
 
     // game state
-    private val _uiState = MutableStateFlow(MathWriteUiState(highScore = initialHighScore))
+    private val _uiState = MutableStateFlow(MathWriteUiState())
     val uiState: StateFlow<MathWriteUiState> = _uiState.asStateFlow()
 
-    fun setOperation(operation: String, highScore: Int = 0) {
+    fun refreshGameStat(gameId: String, fallbackHighScore: Int = 0) {
+        viewModelScope.launch {
+            operationParam = gameId
+            val stats = getGameStatsUseCase(gameId)
+            _gameStats.value = stats
+            highScore = stats?.highScore ?: fallbackHighScore
+            challengesPlayed = stats?.challengesPlayed ?: 0
+            challengesWon = stats?.challengesWon ?: 0
+            challengesLost = stats?.challengesLost ?: 0
+            lastLevel = stats?.lastLevel?.takeIf { it > 0 } ?: 1
+            _uiState.update { it.copy(highScore = highScore.takeIf { score -> score > 0 }) }
+        }
+    }
+
+    fun setOperation(operation: String) {
         operationParam = operation
-        initialHighScore = highScore.takeIf { it > 0 }
         isScorePersisted = false
         viewModelScope.launch {
-            _uiState.update { it.copy(highScore = initialHighScore) }
+            _uiState.update { it.copy(highScore = highScore.takeIf { score -> score > 0 }) }
             launchNewChallenge(resetTimer = true)
         }
     }
@@ -147,6 +169,8 @@ class MathOpWriteResultViewModel @Inject constructor(
 
     private fun handleSuccess() {
         challengesCompleted++
+        challengesPlayed++
+        challengesWon++
         val newScore = _uiState.value.score + SCORE_INCREMENT
         var updatedTimer = timerLength
 
@@ -156,11 +180,13 @@ class MathOpWriteResultViewModel @Inject constructor(
             updatedTimer = timerLength
         }
 
+        highScore = maxOf(highScore, newScore)
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
         _uiState.update {
             it.copy(
                 feedback = ChallengeUiState.Feedback.SUCCESS,
                 score = newScore,
-                highScore = maxOf(it.highScore ?: 0, newScore),
+                highScore = highScore,
                 challengesCompleted = challengesCompleted,
                 challengesPerLevel = challengesPerLevel,
                 timeRemaining = updatedTimer,
@@ -172,6 +198,9 @@ class MathOpWriteResultViewModel @Inject constructor(
 
     private fun handleFailure() {
         val remainingLives = _uiState.value.lives - 1
+        challengesPlayed++
+        challengesLost++
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
         _uiState.update {
             it.copy(
                 lives = remainingLives,
@@ -188,6 +217,9 @@ class MathOpWriteResultViewModel @Inject constructor(
 
     private fun handleCountdownExpired() {
         val remainingLives = _uiState.value.lives - 1
+        challengesPlayed++
+        challengesLost++
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
         _uiState.update { it.copy(lives = remainingLives, feedback = ChallengeUiState.Feedback.FAILURE, timeRemaining = 0L) }
         if (remainingLives <= 0) {
             onGameOver()
@@ -208,6 +240,7 @@ class MathOpWriteResultViewModel @Inject constructor(
     // Increases the current level by 1 and updates the game parameters accordingly.
     private fun promoteLevel() {
         _uiState.update { it.copy(level = it.level + 1) }
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
         operandRangeMin = operandRangeMax
         operandRangeMax = 100 * _uiState.value.level + 50 * (_uiState.value.level - 1)
         multiplicationConfig.maxOperandHigh += 5
@@ -229,13 +262,20 @@ class MathOpWriteResultViewModel @Inject constructor(
         if (isScorePersisted) return
         isScorePersisted = true
         val finalScore = _uiState.value.score
+        highScore = maxOf(highScore, finalScore)
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
+        val updatedStats = GameStats(
+            gameId = operationParam,
+            highScore = highScore,
+            challengesPlayed = challengesPlayed,
+            challengesWon = challengesWon,
+            challengesLost = challengesLost,
+            lastLevel = lastLevel
+        )
+        val previousStats = _gameStats.value
+        _gameStats.value = updatedStats
         viewModelScope.launch {
-            updateGameStatsUseCase(
-                gameId = operationParam,
-                sessionScore = finalScore,
-                isWin = finalScore > 0,
-                lastLevel = _uiState.value.level
-            )
+            updateGameStatsUseCase(previousStats, updatedStats)
             if (finalScore > 0) {
                 updateWriteResultScoreUseCase(scoreCategory, finalScore)
             }

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_op_write/presentation/ui/MathWriteGameScreen.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_op_write/presentation/ui/MathWriteGameScreen.kt
@@ -19,6 +19,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -38,9 +40,19 @@ fun MathWriteGameScreen(
     viewModel: MathOpWriteResultViewModel = hiltViewModel()
 ) {
 
-    // ----------------------------------------- LOGIC -------------------------------------------
-    LaunchedEffect(operation) {
-        viewModel.setOperation(operation, initialHighScore)
+    val gameId = operation
+    val gameStats by viewModel.gameStats.collectAsState()
+    var hasStarted by remember(gameId) { mutableStateOf(false) }
+
+    LaunchedEffect(gameId, initialHighScore) {
+        viewModel.refreshGameStat(gameId, initialHighScore)
+    }
+
+    LaunchedEffect(gameId, gameStats) {
+        if (!hasStarted && gameStats != null) {
+            viewModel.setOperation(gameId)
+            hasStarted = true
+        }
     }
 
     // --- game state
@@ -103,8 +115,8 @@ fun MathWriteGameScreen(
     }
 
     if (state.isGameOver) {
-        LaunchedEffect(operation, initialHighScore) {
-            viewModel.setOperation(operation, initialHighScore)
+        LaunchedEffect(gameId, gameStats) {
+            viewModel.setOperation(gameId)
         }
         GameOverDialog(onDismiss = {
             viewModel.onQuitGame()

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_op_write/presentation/ui/MathWriteGameScreen.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_op_write/presentation/ui/MathWriteGameScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_random_operation/presentation/ui/RandomOperationGameScreen.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_random_operation/presentation/ui/RandomOperationGameScreen.kt
@@ -19,6 +19,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -30,15 +32,27 @@ import eu.indiewalkabout.mathbrainer.core.presentation.components.ResultBanner
 import eu.indiewalkabout.mathbrainer.core.presentation.state.ChallengeUiState
 import eu.indiewalkabout.mathbrainer.feat_games.feat_math_random_operation.presentation.components.RandomOperationChallengeCard
 import eu.indiewalkabout.mathbrainer.feat_games.feat_math_random_operation.presentation.components.RandomOperationHeaderInfo
+import eu.indiewalkabout.mathbrainer.feat_home.domain.model.GameTypes
 
 @Composable
 fun RandomOperationGameScreen(
     initialHighScore: Int = 0,
     onBack: () -> Unit,
-    viewModel: RandomOperationViewModel = hiltViewModel()
+    viewModel: RandomOperationViewModel = hiltViewModel(),
 ) {
-    LaunchedEffect(initialHighScore) {
-        viewModel.startGame(initialHighScore)
+    val gameId = GameTypes.RANDOM_OPERATION.id
+    val gameStats by viewModel.gameStats.collectAsState()
+    var hasStarted by remember(gameId) { mutableStateOf(false) }
+
+    LaunchedEffect(gameId, initialHighScore) {
+        viewModel.refreshGameStat(gameId, initialHighScore)
+    }
+
+    LaunchedEffect(gameId, gameStats) {
+        if (!hasStarted && gameStats != null) {
+            viewModel.startGame()
+            hasStarted = true
+        }
     }
 
     val state by viewModel.uiState.collectAsState()

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_random_operation/presentation/ui/RandomOperationGameScreen.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_random_operation/presentation/ui/RandomOperationGameScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_random_operation/presentation/ui/RandomOperationViewModel.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_math_random_operation/presentation/ui/RandomOperationViewModel.kt
@@ -10,6 +10,8 @@ import eu.indiewalkabout.mathbrainer.feat_games.feat_math_random_operation.domai
 import eu.indiewalkabout.mathbrainer.feat_games.feat_math_random_operation.domain.use_cases.GenerateRandomOperationChallengeUseCase
 import eu.indiewalkabout.mathbrainer.feat_games.feat_math_random_operation.domain.use_cases.UpdateRandomOperationScoreUseCase
 import eu.indiewalkabout.mathbrainer.feat_home.domain.model.GameTypes
+import eu.indiewalkabout.mathbrainer.feat_statistics.domain.model.GameStats
+import eu.indiewalkabout.mathbrainer.feat_statistics.domain.use_cases.GetGameStatsUseCase
 import eu.indiewalkabout.mathbrainer.feat_statistics.domain.use_cases.UpdateGameStatsUseCase
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -24,8 +26,18 @@ import javax.inject.Inject
 class RandomOperationViewModel @Inject constructor(
     private val generateRandomOperationChallengeUseCase: GenerateRandomOperationChallengeUseCase,
     private val updateRandomOperationScoreUseCase: UpdateRandomOperationScoreUseCase,
+    private val getGameStatsUseCase: GetGameStatsUseCase,
     private val updateGameStatsUseCase: UpdateGameStatsUseCase
 ) : ViewModel() {
+
+    private var highScore: Int = 0
+    private var challengesPlayed: Int = 0
+    private var challengesWon: Int = 0
+    private var challengesLost: Int = 0
+    private var lastLevel: Int = 1
+
+    private val _gameStats = MutableStateFlow<GameStats?>(null)
+    val gameStats: StateFlow<GameStats?> = _gameStats.asStateFlow()
 
     // random range of number to be processed
     private var operandRangeMin = 1
@@ -55,8 +67,22 @@ class RandomOperationViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(RandomOperationUiState())
     val uiState: StateFlow<RandomOperationUiState> = _uiState.asStateFlow()
 
+    fun refreshGameStat(gameId: String, fallbackHighScore: Int = 0) {
+        viewModelScope.launch {
+            val stats = getGameStatsUseCase(gameId)
+            _gameStats.value = stats
+            highScore = stats?.highScore ?: fallbackHighScore
+            challengesPlayed = stats?.challengesPlayed ?: 0
+            challengesWon = stats?.challengesWon ?: 0
+            challengesLost = stats?.challengesLost ?: 0
+            lastLevel = stats?.lastLevel?.takeIf { it > 0 } ?: 1
+            _uiState.update { it.copy(highScore = highScore.takeIf { score -> score > 0 }) }
+        }
+    }
+
     fun startGame(initialHighScore: Int = 0) {
-        _uiState.update { it.copy(highScore = initialHighScore.takeIf { score -> score > 0 }) }
+        isScorePersisted = false
+        _uiState.update { it.copy(highScore = highScore.takeIf { score -> score > 0 } ?: initialHighScore.takeIf { it > 0 }) }
         viewModelScope.launch {
             launchNewChallenge(resetTimer = true)
         }
@@ -120,6 +146,8 @@ class RandomOperationViewModel @Inject constructor(
     }
 
     private fun handleSuccess() {
+        challengesPlayed++
+        challengesWon++
         challengesCompleted++
         val newScore = _uiState.value.score + SCORE_INCREMENT
         var updatedTimer = timerLength
@@ -130,11 +158,13 @@ class RandomOperationViewModel @Inject constructor(
             updatedTimer = timerLength
         }
 
+        highScore = maxOf(highScore, newScore)
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
         _uiState.update {
             it.copy(
                 feedback = ChallengeUiState.Feedback.SUCCESS,
                 score = newScore,
-                highScore = maxOf(it.highScore ?: 0, newScore),
+                highScore = highScore,
                 challengesCompleted = challengesCompleted,
                 challengesPerLevel = challengesPerLevel,
                 timeRemaining = updatedTimer,
@@ -146,6 +176,9 @@ class RandomOperationViewModel @Inject constructor(
 
     private fun handleFailure() {
         val remainingLives = _uiState.value.lives - 1
+        challengesPlayed++
+        challengesLost++
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
         _uiState.update {
             it.copy(
                 lives = remainingLives,
@@ -162,6 +195,9 @@ class RandomOperationViewModel @Inject constructor(
 
     private fun handleCountdownExpired() {
         val remainingLives = _uiState.value.lives - 1
+        challengesPlayed++
+        challengesLost++
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
         _uiState.update {
             it.copy(
                 lives = remainingLives,
@@ -189,6 +225,7 @@ class RandomOperationViewModel @Inject constructor(
     // Increases the current level by 1 and updates the game parameters accordingly.
     private fun promoteLevel() {
         _uiState.update { it.copy(level = it.level + 1) }
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
         val level = _uiState.value.level
         operandRangeMin = operandRangeMax
         operandRangeMax = 100 * level + 50 * (level - 1)
@@ -211,13 +248,20 @@ class RandomOperationViewModel @Inject constructor(
         if (isScorePersisted) return
         isScorePersisted = true
         val finalScore = _uiState.value.score
+        highScore = maxOf(highScore, finalScore)
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
+        val updatedStats = GameStats(
+            gameId = GameTypes.RANDOM_OPERATION.id,
+            highScore = highScore,
+            challengesPlayed = challengesPlayed,
+            challengesWon = challengesWon,
+            challengesLost = challengesLost,
+            lastLevel = lastLevel
+        )
+        val previousStats = _gameStats.value
+        _gameStats.value = updatedStats
         viewModelScope.launch {
-            updateGameStatsUseCase(
-                gameId = GameTypes.RANDOM_OPERATION.id,
-                sessionScore = finalScore,
-                isWin = finalScore > 0,
-                lastLevel = _uiState.value.level
-            )
+            updateGameStatsUseCase(previousStats, updatedStats)
             if (finalScore > 0) {
                 updateRandomOperationScoreUseCase(finalScore)
             }

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_memory_flash/presentation/ui/MemoryFlashGameScreen.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_memory_flash/presentation/ui/MemoryFlashGameScreen.kt
@@ -21,6 +21,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -33,15 +35,27 @@ import eu.indiewalkabout.mathbrainer.core.presentation.components.keyboard.Keypa
 import eu.indiewalkabout.mathbrainer.core.presentation.state.ChallengeUiState
 import eu.indiewalkabout.mathbrainer.feat_games.feat_memory_flash.presentation.components.MemoryFlashChallengeCard
 import eu.indiewalkabout.mathbrainer.feat_games.feat_memory_flash.presentation.components.MemoryFlashHeader
+import eu.indiewalkabout.mathbrainer.feat_home.domain.model.GameTypes
 
 @Composable
 fun MemoryFlashGameScreen(
     initialHighScore: Int = 0,
     onBack: () -> Unit,
-    viewModel: MemoryFlashViewModel = hiltViewModel()
+    viewModel: MemoryFlashViewModel = hiltViewModel(),
 ) {
-    LaunchedEffect(initialHighScore) {
-        viewModel.startGame(initialHighScore)
+    val gameId = GameTypes.MEMORY_FLASH.id
+    val gameStats by viewModel.gameStats.collectAsState()
+    var hasStarted by remember(gameId) { mutableStateOf(false) }
+
+    LaunchedEffect(gameId, initialHighScore) {
+        viewModel.refreshGameStat(gameId, initialHighScore)
+    }
+
+    LaunchedEffect(gameId, gameStats) {
+        if (!hasStarted && gameStats != null) {
+            viewModel.startGame()
+            hasStarted = true
+        }
     }
 
     val state by viewModel.uiState.collectAsState()

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_memory_flash/presentation/ui/MemoryFlashGameScreen.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_memory_flash/presentation/ui/MemoryFlashGameScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_memory_flash/presentation/ui/MemoryFlashViewModel.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_memory_flash/presentation/ui/MemoryFlashViewModel.kt
@@ -10,6 +10,8 @@ import eu.indiewalkabout.mathbrainer.feat_games.feat_memory_flash.domain.use_cas
 import eu.indiewalkabout.mathbrainer.feat_games.feat_memory_flash.domain.use_cases.UpdateMemoryFlashScoreUseCase
 import eu.indiewalkabout.mathbrainer.feat_games.feat_memory_flash.presentation.state.MemoryFlashUiState
 import eu.indiewalkabout.mathbrainer.feat_home.domain.model.GameTypes
+import eu.indiewalkabout.mathbrainer.feat_statistics.domain.model.GameStats
+import eu.indiewalkabout.mathbrainer.feat_statistics.domain.use_cases.GetGameStatsUseCase
 import eu.indiewalkabout.mathbrainer.feat_statistics.domain.use_cases.UpdateGameStatsUseCase
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,14 +20,23 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import kotlin.math.max
 
 @HiltViewModel
 class MemoryFlashViewModel @Inject constructor(
     private val generateMemoryFlashChallengeUseCase: GenerateMemoryFlashChallengeUseCase,
     private val updateMemoryFlashScoreUseCase: UpdateMemoryFlashScoreUseCase,
+    private val getGameStatsUseCase: GetGameStatsUseCase,
     private val updateGameStatsUseCase: UpdateGameStatsUseCase
 ) : ViewModel() {
+
+    private var highScore: Int = 0
+    private var challengesPlayed: Int = 0
+    private var challengesWon: Int = 0
+    private var challengesLost: Int = 0
+    private var lastLevel: Int = 1
+
+    private val _gameStats = MutableStateFlow<GameStats?>(null)
+    val gameStats: StateFlow<GameStats?> = _gameStats.asStateFlow()
 
     private var challengesCompletedInternal = 0
     private var challengesPerLevelInternal = INITIAL_CHALLENGES_PER_LEVEL
@@ -35,6 +46,19 @@ class MemoryFlashViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(MemoryFlashUiState())
     val uiState: StateFlow<MemoryFlashUiState> = _uiState.asStateFlow()
 
+    fun refreshGameStat(gameId: String, fallbackHighScore: Int = 0) {
+        viewModelScope.launch {
+            val stats = getGameStatsUseCase(gameId)
+            _gameStats.value = stats
+            highScore = stats?.highScore ?: fallbackHighScore
+            challengesPlayed = stats?.challengesPlayed ?: 0
+            challengesWon = stats?.challengesWon ?: 0
+            challengesLost = stats?.challengesLost ?: 0
+            lastLevel = stats?.lastLevel?.takeIf { it > 0 } ?: 1
+            _uiState.update { it.copy(highScore = highScore.takeIf { score -> score > 0 }) }
+        }
+    }
+
     fun startGame(initialHighScore: Int = 0) {
         isScorePersisted = false
         challengesCompletedInternal = 0
@@ -42,7 +66,8 @@ class MemoryFlashViewModel @Inject constructor(
 
         _uiState.update {
             it.copy(
-                highScore = initialHighScore.takeIf { score -> score > 0 },
+                highScore = highScore.takeIf { score -> score > 0 }
+                    ?: initialHighScore.takeIf { score -> score > 0 },
                 score = 0,
                 level = 1,
                 lives = 3,
@@ -133,11 +158,16 @@ class MemoryFlashViewModel @Inject constructor(
             _uiState.value.level to challengesPerLevelInternal
         }
 
+        challengesPlayed++
+        challengesWon++
+        lastLevel = maxOf(lastLevel, nextLevel)
+        highScore = maxOf(highScore, newScore)
+
         _uiState.update {
             it.copy(
                 feedback = ChallengeUiState.Feedback.SUCCESS,
                 score = newScore,
-                highScore = max(it.highScore ?: 0, newScore),
+                highScore = highScore,
                 challengesCompleted = challengesCompletedInternal,
                 challengesPerLevel = nextChallengesPerLevel,
                 level = nextLevel,
@@ -150,6 +180,9 @@ class MemoryFlashViewModel @Inject constructor(
 
     private fun handleFailure(challenge: MemoryFlashChallenge) {
         val remainingLives = _uiState.value.lives - 1
+        challengesPlayed++
+        challengesLost++
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
         _uiState.update {
             it.copy(
                 lives = remainingLives,
@@ -182,13 +215,20 @@ class MemoryFlashViewModel @Inject constructor(
         if (isScorePersisted) return
         isScorePersisted = true
         val finalScore = _uiState.value.score
+        highScore = maxOf(highScore, finalScore)
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
+        val updatedStats = GameStats(
+            gameId = GameTypes.MEMORY_FLASH.id,
+            highScore = highScore,
+            challengesPlayed = challengesPlayed,
+            challengesWon = challengesWon,
+            challengesLost = challengesLost,
+            lastLevel = lastLevel
+        )
+        val previousStats = _gameStats.value
+        _gameStats.value = updatedStats
         viewModelScope.launch {
-            updateGameStatsUseCase(
-                gameId = GameTypes.MEMORY_FLASH.id,
-                sessionScore = finalScore,
-                isWin = finalScore > 0,
-                lastLevel = _uiState.value.level
-            )
+            updateGameStatsUseCase(previousStats, updatedStats)
             if (finalScore > 0) {
                 updateMemoryFlashScoreUseCase(finalScore)
             }

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_number_order/presentation/ui/NumberOrderGameScreen.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_number_order/presentation/ui/NumberOrderGameScreen.kt
@@ -44,6 +44,7 @@ import eu.indiewalkabout.mathbrainer.core.presentation.components.ResultBanner
 import eu.indiewalkabout.mathbrainer.core.presentation.state.ChallengeUiState
 import eu.indiewalkabout.mathbrainer.feat_games.feat_number_order.domain.model.NumberMarker
 import eu.indiewalkabout.mathbrainer.feat_games.feat_number_order.presentation.components.NumberOrderHeader
+import eu.indiewalkabout.mathbrainer.feat_home.domain.model.GameTypes
 import kotlin.math.max
 import kotlin.math.roundToInt
 import kotlin.random.Random
@@ -52,13 +53,23 @@ import kotlin.random.Random
 fun NumberOrderGameScreen(
     initialHighScore: Int = 0,
     onBack: () -> Unit,
-    viewModel: NumberOrderViewModel = hiltViewModel()
+    viewModel: NumberOrderViewModel = hiltViewModel(),
 ) {
-    val state by viewModel.uiState.collectAsState()
+    val gameId = GameTypes.NUMBER_ORDER.id
+    val gameStats by viewModel.gameStats.collectAsState()
+    var hasStarted by remember(gameId) { mutableStateOf(false) }
 
-    LaunchedEffect(initialHighScore) {
-        viewModel.startGame(initialHighScore)
+    LaunchedEffect(gameId, initialHighScore) {
+        viewModel.refreshGameStat(gameId, initialHighScore)
     }
+
+    LaunchedEffect(gameId, gameStats) {
+        if (!hasStarted && gameStats != null) {
+            viewModel.startGame()
+            hasStarted = true
+        }
+    }
+    val state by viewModel.uiState.collectAsState()
 
     Scaffold(
         topBar = {

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_number_order/presentation/ui/NumberOrderViewModel.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_number_order/presentation/ui/NumberOrderViewModel.kt
@@ -9,6 +9,8 @@ import eu.indiewalkabout.mathbrainer.feat_games.feat_number_order.domain.use_cas
 import eu.indiewalkabout.mathbrainer.feat_games.feat_number_order.domain.use_cases.UpdateNumberOrderScoreUseCase
 import eu.indiewalkabout.mathbrainer.feat_games.feat_number_order.presentation.state.NumberOrderUiState
 import eu.indiewalkabout.mathbrainer.feat_home.domain.model.GameTypes
+import eu.indiewalkabout.mathbrainer.feat_statistics.domain.model.GameStats
+import eu.indiewalkabout.mathbrainer.feat_statistics.domain.use_cases.GetGameStatsUseCase
 import eu.indiewalkabout.mathbrainer.feat_statistics.domain.use_cases.UpdateGameStatsUseCase
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -23,8 +25,18 @@ import javax.inject.Inject
 class NumberOrderViewModel @Inject constructor(
     private val generateNumberOrderChallengeUseCase: GenerateNumberOrderChallengeUseCase,
     private val updateNumberOrderScoreUseCase: UpdateNumberOrderScoreUseCase,
+    private val getGameStatsUseCase: GetGameStatsUseCase,
     private val updateGameStatsUseCase: UpdateGameStatsUseCase
 ) : ViewModel() {
+
+    private var highScore: Int = 0
+    private var challengesPlayed: Int = 0
+    private var challengesWon: Int = 0
+    private var challengesLost: Int = 0
+    private var lastLevel: Int = 1
+
+    private val _gameStats = MutableStateFlow<GameStats?>(null)
+    val gameStats: StateFlow<GameStats?> = _gameStats.asStateFlow()
 
     private var maxItemsToCount = INITIAL_MAX_ITEMS
     private var memorizeDuration = NumberOrderUiState.INITIAL_MEMORIZE_DURATION
@@ -36,10 +48,24 @@ class NumberOrderViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(NumberOrderUiState())
     val uiState: StateFlow<NumberOrderUiState> = _uiState.asStateFlow()
 
+    fun refreshGameStat(gameId: String, fallbackHighScore: Int = 0) {
+        viewModelScope.launch {
+            val stats = getGameStatsUseCase(gameId)
+            _gameStats.value = stats
+            highScore = stats?.highScore ?: fallbackHighScore
+            challengesPlayed = stats?.challengesPlayed ?: 0
+            challengesWon = stats?.challengesWon ?: 0
+            challengesLost = stats?.challengesLost ?: 0
+            lastLevel = stats?.lastLevel?.takeIf { it > 0 } ?: 1
+            _uiState.update { it.copy(highScore = highScore.takeIf { score -> score > 0 }) }
+        }
+    }
+
     fun startGame(initialHighScore: Int = 0) {
-        _uiState.update { 
+        _uiState.update {
             it.copy(
-                highScore = initialHighScore.takeIf { score -> score > 0 },
+                highScore = highScore.takeIf { score -> score > 0 }
+                    ?: initialHighScore.takeIf { score -> score > 0 },
                 challengesPerLevel = INITIAL_CHALLENGES_PER_LEVEL,
                 challengesCompleted = 0,
                 level = 1,
@@ -119,6 +145,9 @@ class NumberOrderViewModel @Inject constructor(
         val newScore = _uiState.value.score + SCORE_INCREMENT
         var newLevel = _uiState.value.level
 
+        challengesPlayed++
+        challengesWon++
+
         // Check if we should level up
         val shouldLevelUp = challengesCompleted >= challengesPerLevel
         if (shouldLevelUp) {
@@ -130,7 +159,7 @@ class NumberOrderViewModel @Inject constructor(
             it.copy(
                 feedback = ChallengeUiState.Feedback.SUCCESS,
                 score = newScore,
-                highScore = maxOf(it.highScore ?: 0, newScore),
+                highScore = maxOf(highScore, newScore).also { updated -> highScore = updated },
                 revealedCount = it.challenge?.itemCount ?: it.revealedCount,
                 challengesCompleted = if (shouldLevelUp) 0 else challengesCompleted,
                 showNextButton = true,
@@ -138,6 +167,8 @@ class NumberOrderViewModel @Inject constructor(
                 challengesPerLevel = challengesPerLevel // Ensure UI state has the latest challengesPerLevel
             )
         }
+
+        lastLevel = maxOf(lastLevel, newLevel)
 
         // Reset challengesCompleted if we've leveled up
         if (shouldLevelUp) {
@@ -149,6 +180,9 @@ class NumberOrderViewModel @Inject constructor(
 
     private fun handleFailure() {
         val remainingLives = _uiState.value.lives - 1
+        challengesPlayed++
+        challengesLost++
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
         _uiState.update {
             it.copy(
                 lives = remainingLives,
@@ -186,13 +220,20 @@ class NumberOrderViewModel @Inject constructor(
         if (isScorePersisted) return
         isScorePersisted = true
         val finalScore = _uiState.value.score
+        highScore = maxOf(highScore, finalScore)
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
+        val updatedStats = GameStats(
+            gameId = GameTypes.NUMBER_ORDER.id,
+            highScore = highScore,
+            challengesPlayed = challengesPlayed,
+            challengesWon = challengesWon,
+            challengesLost = challengesLost,
+            lastLevel = lastLevel
+        )
+        val previousStats = _gameStats.value
+        _gameStats.value = updatedStats
         viewModelScope.launch {
-            updateGameStatsUseCase(
-                gameId = GameTypes.NUMBER_ORDER.id,
-                sessionScore = finalScore,
-                isWin = finalScore > 0,
-                lastLevel = _uiState.value.level
-            )
+            updateGameStatsUseCase(previousStats, updatedStats)
             if (finalScore > 0) {
                 updateNumberOrderScoreUseCase(finalScore)
             }

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/presentation/ui/SequenceCompleteGameScreen.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/presentation/ui/SequenceCompleteGameScreen.kt
@@ -21,6 +21,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -33,15 +35,27 @@ import eu.indiewalkabout.mathbrainer.core.presentation.components.keyboard.Keypa
 import eu.indiewalkabout.mathbrainer.core.presentation.state.ChallengeUiState
 import eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.presentation.components.SequenceChallengeCard
 import eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.presentation.components.SequenceCompleteHeader
+import eu.indiewalkabout.mathbrainer.feat_home.domain.model.GameTypes
 
 @Composable
 fun SequenceCompleteGameScreen(
     initialHighScore: Int = 0,
     onBack: () -> Unit,
-    viewModel: SequenceCompleteViewModel = hiltViewModel()
+    viewModel: SequenceCompleteViewModel = hiltViewModel(),
 ) {
-    LaunchedEffect(initialHighScore) {
-        viewModel.startGame(initialHighScore)
+    val gameId = GameTypes.SEQUENCE_COMPLETE.id
+    val gameStats by viewModel.gameStats.collectAsState()
+    var hasStarted by remember(gameId) { mutableStateOf(false) }
+
+    LaunchedEffect(gameId, initialHighScore) {
+        viewModel.refreshGameStat(gameId, initialHighScore)
+    }
+
+    LaunchedEffect(gameId, gameStats) {
+        if (!hasStarted && gameStats != null) {
+            viewModel.startGame()
+            hasStarted = true
+        }
     }
 
     val state by viewModel.uiState.collectAsState()

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/presentation/ui/SequenceCompleteGameScreen.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/presentation/ui/SequenceCompleteGameScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/presentation/ui/SequenceCompleteViewModel.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_games/feat_sequence_complete/presentation/ui/SequenceCompleteViewModel.kt
@@ -10,6 +10,8 @@ import eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.domain.us
 import eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.domain.use_cases.UpdateSequenceCompleteScoreUseCase
 import eu.indiewalkabout.mathbrainer.feat_games.feat_sequence_complete.presentation.state.SequenceCompleteUiState
 import eu.indiewalkabout.mathbrainer.feat_home.domain.model.GameTypes
+import eu.indiewalkabout.mathbrainer.feat_statistics.domain.model.GameStats
+import eu.indiewalkabout.mathbrainer.feat_statistics.domain.use_cases.GetGameStatsUseCase
 import eu.indiewalkabout.mathbrainer.feat_statistics.domain.use_cases.UpdateGameStatsUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -17,14 +19,23 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import kotlin.math.max
 
 @HiltViewModel
 class SequenceCompleteViewModel @Inject constructor(
     private val generateSequenceChallengeUseCase: GenerateSequenceChallengeUseCase,
     private val updateSequenceCompleteScoreUseCase: UpdateSequenceCompleteScoreUseCase,
+    private val getGameStatsUseCase: GetGameStatsUseCase,
     private val updateGameStatsUseCase: UpdateGameStatsUseCase
 ) : ViewModel() {
+
+    private var highScore: Int = 0
+    private var challengesPlayed: Int = 0
+    private var challengesWon: Int = 0
+    private var challengesLost: Int = 0
+    private var lastLevel: Int = 1
+
+    private val _gameStats = MutableStateFlow<GameStats?>(null)
+    val gameStats: StateFlow<GameStats?> = _gameStats.asStateFlow()
 
     private var challengesCompletedInternal = 0
     private var challengesPerLevelInternal = SequenceCompleteUiState.INITIAL_CHALLENGES_PER_LEVEL
@@ -34,6 +45,19 @@ class SequenceCompleteViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(SequenceCompleteUiState())
     val uiState: StateFlow<SequenceCompleteUiState> = _uiState.asStateFlow()
 
+    fun refreshGameStat(gameId: String, fallbackHighScore: Int = 0) {
+        viewModelScope.launch {
+            val stats = getGameStatsUseCase(gameId)
+            _gameStats.value = stats
+            highScore = stats?.highScore ?: fallbackHighScore
+            challengesPlayed = stats?.challengesPlayed ?: 0
+            challengesWon = stats?.challengesWon ?: 0
+            challengesLost = stats?.challengesLost ?: 0
+            lastLevel = stats?.lastLevel?.takeIf { it > 0 } ?: 1
+            _uiState.update { it.copy(highScore = highScore.takeIf { score -> score > 0 }) }
+        }
+    }
+
     fun startGame(initialHighScore: Int = 0) {
         isScorePersisted = false
         challengesCompletedInternal = 0
@@ -41,7 +65,8 @@ class SequenceCompleteViewModel @Inject constructor(
 
         _uiState.update {
             it.copy(
-                highScore = initialHighScore.takeIf { score -> score > 0 },
+                highScore = highScore.takeIf { score -> score > 0 }
+                    ?: initialHighScore.takeIf { score -> score > 0 },
                 score = 0,
                 level = 1,
                 lives = 3,
@@ -121,11 +146,16 @@ class SequenceCompleteViewModel @Inject constructor(
             _uiState.value.level to challengesPerLevelInternal
         }
 
+        challengesPlayed++
+        challengesWon++
+        lastLevel = maxOf(lastLevel, nextLevel)
+        highScore = maxOf(highScore, newScore)
+
         _uiState.update {
             it.copy(
                 feedback = ChallengeUiState.Feedback.SUCCESS,
                 score = newScore,
-                highScore = max(it.highScore ?: 0, newScore),
+                highScore = highScore,
                 challengesCompleted = challengesCompletedInternal,
                 challengesPerLevel = nextChallengesPerLevel,
                 level = nextLevel,
@@ -139,6 +169,9 @@ class SequenceCompleteViewModel @Inject constructor(
 
     private fun handleFailure(challenge: SequenceChallenge) {
         val remainingLives = _uiState.value.lives - 1
+        challengesPlayed++
+        challengesLost++
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
         _uiState.update {
             it.copy(
                 lives = remainingLives,
@@ -171,13 +204,20 @@ class SequenceCompleteViewModel @Inject constructor(
         if (isScorePersisted) return
         isScorePersisted = true
         val finalScore = _uiState.value.score
+        highScore = maxOf(highScore, finalScore)
+        lastLevel = maxOf(lastLevel, _uiState.value.level)
+        val updatedStats = GameStats(
+            gameId = GameTypes.SEQUENCE_COMPLETE.id,
+            highScore = highScore,
+            challengesPlayed = challengesPlayed,
+            challengesWon = challengesWon,
+            challengesLost = challengesLost,
+            lastLevel = lastLevel
+        )
+        val previousStats = _gameStats.value
+        _gameStats.value = updatedStats
         viewModelScope.launch {
-            updateGameStatsUseCase(
-                gameId = GameTypes.SEQUENCE_COMPLETE.id,
-                sessionScore = finalScore,
-                isWin = finalScore > 0,
-                lastLevel = _uiState.value.level
-            )
+            updateGameStatsUseCase(previousStats, updatedStats)
             if (finalScore > 0) {
                 updateSequenceCompleteScoreUseCase(finalScore)
             }

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_statistics/domain/use_cases/UpdateGameStatsUseCase.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_statistics/domain/use_cases/UpdateGameStatsUseCase.kt
@@ -8,6 +8,19 @@ import kotlin.math.max
 class UpdateGameStatsUseCase @Inject constructor(
     private val repository: MathBrainerRepository
 ) {
+    suspend operator fun invoke(previousStats: GameStats?, updatedStats: GameStats) {
+        if (updatedStats.gameId.isBlank()) return
+
+        val currentStats = previousStats ?: repository.getGameStats(updatedStats.gameId) ?: GameStats(gameId = updatedStats.gameId)
+
+        val mergedStats = updatedStats.copy(
+            highScore = max(currentStats.highScore, updatedStats.highScore),
+            lastLevel = max(currentStats.lastLevel, updatedStats.lastLevel)
+        )
+
+        repository.insertGameStats(mergedStats)
+    }
+
     suspend operator fun invoke(gameId: String, sessionScore: Int, isWin: Boolean, lastLevel: Int) {
         if (gameId.isBlank()) return
 

--- a/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_statistics/domain/use_cases/UpdateGameStatsUseCase.kt
+++ b/app/src/main/java/eu/indiewalkabout/mathbrainer/feat_statistics/domain/use_cases/UpdateGameStatsUseCase.kt
@@ -1,5 +1,6 @@
 package eu.indiewalkabout.mathbrainer.feat_statistics.domain.use_cases
 
+import android.util.Log
 import eu.indiewalkabout.mathbrainer.feat_statistics.domain.model.GameStats
 import eu.indiewalkabout.mathbrainer.feat_statistics.domain.repository.MathBrainerRepository
 import javax.inject.Inject
@@ -11,32 +12,15 @@ class UpdateGameStatsUseCase @Inject constructor(
     suspend operator fun invoke(previousStats: GameStats?, updatedStats: GameStats) {
         if (updatedStats.gameId.isBlank()) return
 
-        val currentStats = previousStats ?: repository.getGameStats(updatedStats.gameId) ?: GameStats(gameId = updatedStats.gameId)
+        val currentStats = previousStats ?:
+                repository.getGameStats(updatedStats.gameId) ?:
+                GameStats(gameId = updatedStats.gameId)
 
         val mergedStats = updatedStats.copy(
             highScore = max(currentStats.highScore, updatedStats.highScore),
             lastLevel = max(currentStats.lastLevel, updatedStats.lastLevel)
         )
-
+        Log.d("UpdateGameStatsUseCase", "Merged stats: $mergedStats")
         repository.insertGameStats(mergedStats)
-    }
-
-    suspend operator fun invoke(gameId: String, sessionScore: Int, isWin: Boolean, lastLevel: Int) {
-        if (gameId.isBlank()) return
-
-        // TODO: must be passed as parameters
-        val currentStats = repository.getGameStats(gameId) ?: GameStats(gameId = gameId)
-
-        val shouldUpdateHighScore = currentStats.highScore == 0 || sessionScore >= currentStats.highScore
-
-        val updatedStats = currentStats.copy(
-            highScore = if (shouldUpdateHighScore) sessionScore else currentStats.highScore,
-            challengesPlayed = currentStats.challengesPlayed + 1,
-            challengesWon = currentStats.challengesWon + if (isWin) 1 else 0,
-            challengesLost = currentStats.challengesLost + if (isWin) 0 else 1,
-            lastLevel = max(currentStats.lastLevel, lastLevel)
-        )
-
-        repository.insertGameStats(updatedStats)
     }
 }


### PR DESCRIPTION
## Summary
- update game view models to build merged GameStats payloads from local counters and existing data
- persist refreshed stats on game over using the UpdateGameStatsUseCase previous/updated overload

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69524dc11224832a800904cbcd9f50ec)